### PR TITLE
Use vagrant user and minor changes

### DIFF
--- a/playbooks/archivematica/.gitignore
+++ b/playbooks/archivematica/.gitignore
@@ -1,2 +1,3 @@
-roles
-.vagrant
+/roles
+/.vagrant
+/src

--- a/playbooks/archivematica/ansible.cfg
+++ b/playbooks/archivematica/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
 nocows=1
+
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes -F ssh.config -o ControlMaster=auto -o ControlPersist=60s

--- a/playbooks/archivematica/hosts
+++ b/playbooks/archivematica/hosts
@@ -1,1 +1,1 @@
-am-local ansible_ssh_host=192.168.168.192 ansible_ssh_user=root
+am-local ansible_ssh_host=192.168.168.192 ansible_ssh_user=vagrant ansible_ssh_pass=vagrant

--- a/playbooks/archivematica/singlenode.yml
+++ b/playbooks/archivematica/singlenode.yml
@@ -1,10 +1,35 @@
 ---
-- hosts: am-local
+- hosts: "am-local"
+
   pre_tasks:
-    - include_vars: vars-singlenode.yml
+
+    - include_vars: "vars-singlenode.yml"
+      tags:
+        - "always"
+
   roles:
-    - role: elasticsearch
-    - role: percona
-    - role: gearman
-    - role: nginx
-    - role: archivematica-src
+
+    - role: "elasticsearch"
+      sudo: "yes"
+      tags:
+        - "elasticsearch"
+
+    - role: "percona"
+      sudo: "yes"
+      tags:
+        - "percona"
+
+    - role: "gearman"
+      sudo: "yes"
+      tags:
+        - "gearman"
+
+    - role: "nginx"
+      sudo: "yes"
+      tags:
+        - "nginx"
+
+    - role: "archivematica-src"
+      sudo: "yes"
+      tags:
+        - "archivematica-src"

--- a/playbooks/archivematica/ssh.config
+++ b/playbooks/archivematica/ssh.config
@@ -2,5 +2,5 @@
 Host 192.168.168.* *.myapp.dev
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
-  User root
+  User vagrant
   LogLevel ERROR

--- a/playbooks/archivematica/vars-singlenode.yml
+++ b/playbooks/archivematica/vars-singlenode.yml
@@ -1,20 +1,22 @@
 ---
-# Archivematica Ansible Variables
 
-ppa: 'archivematica/externals-dev'
+# archivematica-src role
 
-amdev_version: 'remotes/origin/qa/1.x'
-ssdev_version: 'remotes/origin/qa/0.x'
+archivematica_src_dir: "/vagrant/src"
+archivematica_src_environment_type: "development"
+amdev_version: "remotes/origin/qa/1.x"
+ssdev_version: "remotes/origin/qa/0.x"
+ppa: "archivematica/externals-dev"
 
-# Elasticsearch Ansible Variables
+# elasticsearch role
 
-elasticsearch_version: 1.4.4
-elasticsearch_apt_java_package: oracle-java8-installer
-elasticsearch_java_home: /usr/lib/jvm/java-8-oracle
-elasticsearch_heap_size: 400m
-elasticsearch_max_open_files: 65535
+elasticsearch_version: "1.4.4"
+elasticsearch_apt_java_package: "oracle-java8-installer"
+elasticsearch_java_home: "/usr/lib/jvm/java-8-oracle"
+elasticsearch_heap_size: "400m"
+elasticsearch_max_open_files: "65535"
 elasticsearch_timezone: "America/Vancouver"
-elasticsearch_node_max_local_storage_nodes: 1
+elasticsearch_node_max_local_storage_nodes: "1"
 elasticsearch_index_mapper_dynamic: "true"
 elasticsearch_memory_bootstrap_mlockall: "true"
 elasticsearch_install_java: "true"
@@ -23,5 +25,6 @@ elasticsearch_thread_pools:
   - "threadpool.bulk.size: 50"
   - "threadpool.bulk.queue_size: 1000"
 
-# Percona Ansible Variables
-mysql_root_password: U6ygtjCHQ84NuyDk
+# percona role
+
+mysql_root_password: "U6ygtjCHQ84NuyDk"


### PR DESCRIPTION
This PR is for the playbooks/archivematica branch.
- Add tags to singlenode.yml.
- Assign "/vagrant/src" to `archivematica_src_dir` so the contents are visible from the host machine, making things easier for the developer that doesn't run the source code editor in the virtual machine.
- Rely on the `vagrant` user to do the deployment as this user can scale to root without password prompt with sudo.
