### PR TITLE
Add archivematica-src playbooks for centos-7 and trusty

### DIFF
--- a/playbooks/archivematica-src-centos-7/.gitignore
+++ b/playbooks/archivematica-src-centos-7/.gitignore
@@ -1,0 +1,3 @@
+/roles
+/.vagrant
+/src

--- a/playbooks/archivematica-src-centos-7/README.md
+++ b/playbooks/archivematica-src-centos-7/README.md
@@ -1,0 +1,61 @@
+# Archivematica playbook
+
+The provided playbook installs Archivematica on a local vagrant virtual
+machine. For instructions on using deploy-pub to install Archivematica on a
+Digital Ocean droplet, see the [Digital Ocean Droplet
+Deploy](docs/digital-ocean-install-example.rst) document.
+
+## Requirements
+
+- Vagrant 1.9.2 or newer (note that vagrant 1.9.1 has a bug when restarting network services in RHEL https://github.com/mitchellh/vagrant/pull/8148)
+- Ansible 2.2 or newer
+
+## How to use
+
+1. Download the Ansible roles:
+  ```
+  $ ansible-galaxy install -f -p roles/ -r requirements.yml
+  ```
+
+2. Create the virtual machine and provision it:
+  ```
+  $ vagrant up
+  ```
+  After provisioning ends, Achivematica UI should be accessible at http://xxx.xxx.xxx.xxx and the Storage Service UI at http://xxx.xxx.xxx.xxx:8000 where xxx.xxx.xxx.xxx is the IP address specified in the `ip` variable of the Vagrantfile
+
+3. To ssh to the VM, run:
+  ```
+  $ vagrant ssh
+  ```
+
+4. If you want to forward your SSH agent too, run:
+  ```
+  $ vagrant ssh -- -A
+  ```
+
+5. To (re-)provision the VM, run:
+    * Using vagrant:
+        ```
+        $ vagrant provision
+        ```
+    * Using vagrant and custom ANSIBLE_ARGS. Use colons (:) to separate multiple parameters. For example to pass a tag to install Storage Service only, and verbose flag:
+        ```
+        $ ANSIBLE_ARGS="--tags=amsrc-ss:-vvv" vagrant provision       (in bash)
+        $ env ANSIBLE_ARGS="--tags=amsrc-ss:-vvv" vagrant provision   (in fish)
+        ```
+      Note that it is not possible to pass the (--extra-vars to ansible using the above, because extra_vars is reassigned in the Vagrantfile)
+    * Using ansible commands directly (this allows you to pass ansible-specific parameters,
+      such as tags and the verbose flag; remember to use extra-vars to pass the variables in the Vagrantfile ):
+        ```
+        $ ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory singlenode.yml \
+           -u vagrant \
+           --private-key .vagrant/machines/am-local/virtualbox/private_key \
+           --extra-vars="archivematica_src_dir=/vagrant/src archivematica_src_environment_type=development" \
+           --tags="amsrc-pipeline-instcode" \
+           -v
+        ```
+
+6. The ansible playbook `singlenode.yml` specified in the Vagrantfile will provision using the branches of archivematica specfied in the file `vars-singlenode.yml`. Edit this file if need to deploy other branches.  
+
+
+For more archivematica development information, see: https://wiki.archivematica.org/Getting_started

--- a/playbooks/archivematica-src-centos-7/Vagrantfile
+++ b/playbooks/archivematica-src-centos-7/Vagrantfile
@@ -1,0 +1,47 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = ENV.fetch("VAGRANT_BOX", "centos/7")
+
+  {
+    "am-local-centos7" => {
+      "ip" => "192.168.168.197",
+      "memory" => "3072",
+      "cpus" => "2",
+    },
+  }.each do |short_name, properties|
+
+    # Define guest
+    config.vm.define short_name do |host|
+      host.vm.network "private_network", ip: properties.fetch("ip")
+    end
+
+    # Set the amount of RAM and virtual CPUs for the virtual machine
+    config.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", properties.fetch("memory")]
+      vb.customize ["modifyvm", :id, "--cpus", properties.fetch("cpus")]
+    end
+
+  end
+
+  # Make the project root available to the guest VM
+  config.vm.synced_folder '.', '/vagrant'
+
+  # Ansible provisioning
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "./singlenode.yml"
+    ansible.host_key_checking = false
+    ansible.extra_vars = {
+      "archivematica_src_dir" => "/vagrant/src",
+      "archivematica_src_environment_type" => "development",
+    }
+    #ansible.raw_arguments = ENV['ANSIBLE_ARGS']
+    # accept multiple arguments, separated by colons
+    ansible.raw_arguments = ENV['ANSIBLE_ARGS'].to_s.split(':')
+  end
+end

--- a/playbooks/archivematica-src-centos-7/requirements.yml
+++ b/playbooks/archivematica-src-centos-7/requirements.yml
@@ -1,0 +1,18 @@
+---
+
+- src: "https://github.com/elastic/ansible-elasticsearch"
+  version: "2.x"
+  name: "elastic.elasticsearch"
+
+- src: "https://github.com/jdauphant/ansible-role-nginx"
+  version: "master"
+  name: "jdauphant.nginx"
+
+- src: "https://github.com/artefactual-labs/ansible-clamav"
+  version: "master"
+  name: "clamav"
+
+- src: "https://github.com/artefactual-labs/ansible-role-archivematica-src"
+  version: "dev/pkg-deps-in-src-repo-ub-rh"
+  name: "archivematica-src"
+  

--- a/playbooks/archivematica-src-centos-7/singlenode.retry
+++ b/playbooks/archivematica-src-centos-7/singlenode.retry
@@ -1,0 +1,1 @@
+am-local-centos7

--- a/playbooks/archivematica-src-centos-7/singlenode.yml
+++ b/playbooks/archivematica-src-centos-7/singlenode.yml
@@ -1,0 +1,69 @@
+---
+- hosts: "am-local-centos7"
+
+  pre_tasks:
+
+    - include_vars: "vars-singlenode.yml"
+      tags:
+        - "always"
+
+    - name: "Set SELinux to Permissive"
+      command: "setenforce Permissive"      
+      become: "yes"
+
+    - name: "Enable epel repository"
+      yum:
+        name: "epel-release"
+        state: "latest"
+      become: "yes"
+
+    - name: "Install mariadb-server, gearman"
+      yum:
+        name: "{{ item }}"
+        state: "latest"
+      with_items:
+        - "mariadb-server"
+        - "gearmand"
+      become: "yes"
+
+    - name: "Enable and start mariadb, gearman servers"   
+      service:
+        name: "{{ item }}"
+        state: "started"
+        enabled: "yes"
+      with_items:
+        - "mariadb"
+        - "gearmand"
+      become: "yes"
+
+  roles:
+    - { role: "elastic.elasticsearch", 
+        tags: ["elasticsearch"], 
+        become: "yes",
+        # instance specific settings here, general settings in host_vars
+        es_instance_name: "node1", 
+        es_data_dirs: "/opt/elasticsearch/data", 
+        es_log_dir: "/opt/elasticsearch/logs", 
+        es_work_dir: "/opt/elasticsearch/temp", 
+        es_config: {
+          node.name: "node1", 
+          cluster.name: "cluster1",
+          http.port: 9200,
+          transport.tcp.port: 9300,
+          node.data: true,
+          node.master: true,
+          bootstrap.mlockall: true,
+          discovery.zen.ping.multicast.enabled: false,
+          http.max_content_length: 1024mb 
+          }
+      }
+    - { role: "clamav", tags: ["clamav"], become: "yes" }
+    - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
+    - { role: "archivematica-src", tags: ["archivematica-src"], become: "yes" }
+
+  tasks:
+    - name: "change home dir perms (to make transfer source visible)"
+      command: "chmod 755 $HOME" 
+      tags: "homeperms"
+      become: "no"
+

--- a/playbooks/archivematica-src-centos-7/vars-singlenode.yml
+++ b/playbooks/archivematica-src-centos-7/vars-singlenode.yml
@@ -1,0 +1,30 @@
+---
+
+# archivematica-src role
+
+archivematica_src_install_devtools: "no"
+archivematica_src_am_version: "dev/deployment-osdeps-ub-rh"
+archivematica_src_ss_version: "dev/deployment-osdeps-ub-rh"
+archivematica_src_ss_gunicorn: "true"
+archivematica_src_am_dashboard_gunicorn: "true"
+archivematica_src_am_multi_venvs: "yes"
+
+# reset setup vars, commented out here, uncomment if needed
+#archivematica_src_reset_am_all: "true"
+#archivematica_src_reset_ss_db: "true"
+
+# elasticsearch role, general settings 
+# (instance specific settings are in the playbook )
+es_scripts: false
+es_templates: false
+es_version_lock: false
+es_heap_size: 348m
+es_major_version: "1.7"
+es_version: "1.7.5"
+es_start_service: true
+es_java_install: true
+update_java: true
+es_restart_on_change: true
+es_allow_downgrades: false
+es_enable_xpack: false
+es_xpack_features: []

--- a/playbooks/archivematica-src-trusty/.gitignore
+++ b/playbooks/archivematica-src-trusty/.gitignore
@@ -1,0 +1,3 @@
+/roles
+/.vagrant
+/src

--- a/playbooks/archivematica-src-trusty/README.md
+++ b/playbooks/archivematica-src-trusty/README.md
@@ -1,0 +1,61 @@
+# Archivematica playbook
+
+The provided playbook installs Archivematica on a local vagrant virtual
+machine. For instructions on using deploy-pub to install Archivematica on a
+Digital Ocean droplet, see the [Digital Ocean Droplet
+Deploy](docs/digital-ocean-install-example.rst) document.
+
+## Requirements
+
+- Vagrant 1.7 or newer
+- Ansible 2.2 or newer
+
+## How to use
+
+1. Download the Ansible roles:
+  ```
+  $ ansible-galaxy install -f -p roles/ -r requirements.yml
+  ```
+
+2. Create the virtual machine and provision it:
+  ```
+  $ vagrant up
+  ```
+  After provisioning ends, Achivematica UI should be accessible at http://xxx.xxx.xxx.xxx and the Storage Service UI at http://xxx.xxx.xxx.xxx:8000 where xxx.xxx.xxx.xxx is the IP address specified in the `ip` variable of the Vagrantfile
+
+3. To ssh to the VM, run:
+  ```
+  $ vagrant ssh
+  ```
+
+4. If you want to forward your SSH agent too, run:
+  ```
+  $ vagrant ssh -- -A
+  ```
+
+5. To (re-)provision the VM, run:
+    * Using vagrant:
+        ```
+        $ vagrant provision
+        ```
+    * Using vagrant and custom ANSIBLE_ARGS. Use colons (:) to separate multiple parameters. For example to pass a tag to install Storage Service only, and verbose flag:
+        ```
+        $ ANSIBLE_ARGS="--tags=amsrc-ss:-vvv" vagrant provision       (in bash)
+        $ env ANSIBLE_ARGS="--tags=amsrc-ss:-vvv" vagrant provision   (in fish)
+        ```
+      Note that it is not possible to pass the (--extra-vars to ansible using the above, because extra_vars is reassigned in the Vagrantfile)
+    * Using ansible commands directly (this allows you to pass ansible-specific parameters,
+      such as tags and the verbose flag; remember to use extra-vars to pass the variables in the Vagrantfile ):
+        ```
+        $ ansible-playbook -i .vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory singlenode.yml \
+           -u vagrant \
+           --private-key .vagrant/machines/am-local/virtualbox/private_key \
+           --extra-vars="archivematica_src_dir=/vagrant/src archivematica_src_environment_type=development" \
+           --tags="amsrc-pipeline-instcode" \
+           -v
+        ```
+
+6. The ansible playbook `singlenode.yml` specified in the Vagrantfile will provision using the branches of archivematica specfied in the file `vars-singlenode.yml`. Edit this file if need to deploy other branches.  
+
+
+For more archivematica development information, see: https://wiki.archivematica.org/Getting_started

--- a/playbooks/archivematica-src-trusty/Vagrantfile
+++ b/playbooks/archivematica-src-trusty/Vagrantfile
@@ -1,0 +1,47 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  config.vm.box = ENV.fetch("VAGRANT_BOX", "ubuntu/trusty64")
+
+  {
+    "am-local-trusty" => {
+      "ip" => "192.168.168.196",
+      "memory" => "3072",
+      "cpus" => "2",
+    },
+  }.each do |short_name, properties|
+
+    # Define guest
+    config.vm.define short_name do |host|
+      host.vm.network "private_network", ip: properties.fetch("ip")
+    end
+
+    # Set the amount of RAM and virtual CPUs for the virtual machine
+    config.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", properties.fetch("memory")]
+      vb.customize ["modifyvm", :id, "--cpus", properties.fetch("cpus")]
+    end
+
+  end
+
+  # Make the project root available to the guest VM
+  config.vm.synced_folder '.', '/vagrant'
+
+  # Ansible provisioning
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "./singlenode.yml"
+    ansible.host_key_checking = false
+    ansible.extra_vars = {
+      "archivematica_src_dir" => "/vagrant/src",
+      "archivematica_src_environment_type" => "development",
+    }
+    #ansible.raw_arguments = ENV['ANSIBLE_ARGS']
+    # accept multiple arguments, separated by colons
+    ansible.raw_arguments = ENV['ANSIBLE_ARGS'].to_s.split(':')
+  end
+end

--- a/playbooks/archivematica-src-trusty/ansible.cfg
+++ b/playbooks/archivematica-src-trusty/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+nocows = 1

--- a/playbooks/archivematica-src-trusty/docs/digital-ocean-install-example.rst
+++ b/playbooks/archivematica-src-trusty/docs/digital-ocean-install-example.rst
@@ -1,0 +1,138 @@
+How to Deploy Archivematica to a Digital Ocean Droplet
+================================================================================
+
+This document describes how to deploy Archivematica to a Digital Ocean droplet
+(i.e., virtual private server, VPS).  It assumes that you have basic
+proficiency with the Unix command-line and that you have the following
+installed.
+
+- git
+- Python
+- Ansible (http://docs.ansible.com/ansible/intro_installation.html)
+
+We are also assuming that you have a Digital Ocean account and that you have
+created a new droplet. The following URL may be useful for accomplishing this.
+
+- https://www.digitalocean.com/community/tutorials/how-to-create-your-first-digitalocean-droplet-virtual-server
+
+In this example, we are using Ubuntu 14.04.
+
+
+1. Clone the git repository that contains the Ansible configuration files which
+   will be used to install Archivematica and all of its dependencies onto the
+   Digital Ocean droplet::
+
+    $ git clone https://github.com/artefactual/deploy-pub.git
+
+2. Download the Ansible roles that will install Archivematica and its
+   dependencies::
+
+    $ cd deploy-pub/playbooks/archivematica
+    $ ansible-galaxy install -f -p roles/ -r requirements.yml
+
+3. Create a ``hosts`` file to tell Ansible the alias for our droplet (``am-do``),
+   its IP address and that we want to use the root user (where
+   ``xxx.xxx.xxx.xxx`` is the droplet's actual IP)::
+
+    $ cat hosts
+    am-do ansible_host=xxx.xxx.xxx.xxx ansible_user=root
+
+4. Modify the Ansible config file ``ansible.cfg`` to point to our ``hosts`` file::
+
+    $ cat ansible.cfg
+    [defaults]
+    nocows = 1
+    inventory = hosts
+
+5. If you do not have a SSH key, create one now (accepting the defaults)::
+
+    $ ssh-keygen -t rsa
+
+6. Copy the output of the above command to your clipboard and save it to your
+   digital ocean droplet in the "New SSH Key" web interface (see
+   https://cloud.digitalocean.com/settings/security)::
+
+    $ cat ~/.ssh/id_rsa.pub
+
+7. Use Ansible to create a new user on our Digital Ocean droplet. Create a file
+   (an Ansible playbook) called ``user.yml`` which has the content indicated by
+   the output of ``cat`` below::
+
+    $ cat user.yml
+    ---
+    - name: create artefactual user
+      hosts: am-do
+      tasks:
+
+        - name: add artefactual user
+          user: name=artefactual shell=/bin/bash
+
+        - name: add ssh keys to the corresponding user
+          authorized_key: user=artefactual
+                          key="{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+
+        - name: configure passwordless sudo for the artefactual user
+          lineinfile: dest=/etc/sudoers
+                      state=present
+                      regexp='^artefactual ALL\='
+                      line='artefactual ALL=(ALL) NOPASSWD:ALL'
+                      validate='/usr/sbin/visudo -cf %s'
+
+The ``user.yml`` file creates a user called "artefactual" on the droplet, adds
+your public key (assumed to be in ``~/.ssh/id_rsa.pub``) to the droplet, and
+allows the artefactual user to run commands using ``sudo`` without a password.
+Choose a different username than "artefactual" if you want.
+
+8. Modify the ``hosts`` file to use the appropriate (e.g., ``artefactual``) user::
+
+    $ cat hosts
+    am-do ansible_host=xxx.xxx.xxx.xxx ansible_user=artefactual
+
+
+9. Confirm that you can access the Digital Ocean droplet via SSH::
+
+    $ ssh artefactual@xxx.xxx.xxx.xxx
+
+10. And via Ansible::
+
+    $ ansible am-do -m ping
+    am-do | SUCCESS => {
+        "changed": false, 
+        "ping": "pong"
+    }
+
+11. If desired, alter the value of the ``archivematica_src_ss_version`` variable
+    in ``deploy-pub/playbooks/archivematica/vars-singlenode.yml`` so that
+    instead of "qa/1.x" it valuates to another Archivematica branch, e.g.,
+    "dev/issue-9213-1.5-integration".
+
+12. Install and deploy Archivematica and its dependencies::
+
+    $ ansible-playbook singlenode.yml
+
+The above command will take several minutes. If successful, the final output
+should indicate ``unreachable=0 failed=0``.
+
+Note: the ``ansible-playbook singlenode.yml`` command may fail initially. If it
+does, try it again.
+
+13. Confirm that Archivematica and its dependencies are installed and working
+    by navigating to your Digital Ocean droplet's IP address
+    (http://xxx.xxx.xxx.xxx). The Archivematica Storage Service should be being
+    served at the same IP on port 8000, i.e., http://xxx.xxx.xxx.xxx:8000.
+
+The default username and password for accessing the Storage Service are "test"
+and "test". Once you log in, go to the "Administration" tab, then click "Users"
+on the lefthand column, then click the "Edit" button of the "test" user, then
+copy the API key at the bottom of the page to your clipboard.
+
+Then navigate to the Archivematica dashboard (http://xxx.xxx.xxx.xxx), fill in
+the form, and click "Create". When communication with the FPR Server has
+completed, click the "continue" button. Now enter the API key that you copied
+from the Storage Service and click the first button, the one labelled "Register
+with the storage service & use default configuration."
+
+You can test that your Archivematica installation works by performing a sample
+Transfer and Ingest.
+
+

--- a/playbooks/archivematica-src-trusty/requirements.yml
+++ b/playbooks/archivematica-src-trusty/requirements.yml
@@ -1,0 +1,26 @@
+---
+
+- src: "https://github.com/artefactual-labs/ansible-elasticsearch"
+  version: "master"
+  name: "elasticsearch"
+
+- src: "https://github.com/artefactual-labs/ansible-percona"
+  version: "master"
+  name: "percona"
+
+- src: "https://github.com/artefactual-labs/ansible-gearman"
+  version: "master"
+  name: "gearman"
+
+- src: "https://github.com/artefactual-labs/ansible-nginx"
+  version: "master"
+  name: "nginx"
+
+- src: "https://github.com/artefactual-labs/ansible-clamav"
+  version: "master"
+  name: "clamav"
+
+- src: "https://github.com/artefactual-labs/ansible-role-archivematica-src"
+  version: "dev/pkg-deps-in-src-repo-ub-rh"
+  name: "archivematica-src"
+  

--- a/playbooks/archivematica-src-trusty/singlenode.retry
+++ b/playbooks/archivematica-src-trusty/singlenode.retry
@@ -1,0 +1,1 @@
+am-local

--- a/playbooks/archivematica-src-trusty/singlenode.yml
+++ b/playbooks/archivematica-src-trusty/singlenode.yml
@@ -1,0 +1,23 @@
+---
+- hosts: "am-local-trusty"
+
+  pre_tasks:
+
+    - include_vars: "vars-singlenode.yml"
+      tags:
+        - "always"
+
+    - name: "Install packages for development convenience"
+      apt:
+        pkg: "{{ item }}"
+        state: "latest"
+      with_items:
+        - "fish"
+      become: "yes"
+
+  roles:
+    - { role: "elasticsearch", tags: ["elasticsearch"], become: "yes" }
+    - { role: "percona", tags: ["percona"], become: "yes" }
+    - { role: "gearman", tags: ["gearman"], become: "yes" }
+    - { role: "clamav", tags: ["clamav"], become: "yes" }
+    - { role: "archivematica-src", tags: ["archivematica-src"], become: "yes" }

--- a/playbooks/archivematica-src-trusty/vars-singlenode.yml
+++ b/playbooks/archivematica-src-trusty/vars-singlenode.yml
@@ -1,0 +1,34 @@
+---
+
+# archivematica-src role
+
+archivematica_src_install_devtools: "yes"
+archivematica_src_am_version: "dev/deployment-osdeps-ub-rh"
+archivematica_src_ss_version: "dev/deployment-osdeps-ub-rh"
+archivematica_src_ss_gunicorn: "true"
+archivematica_src_am_dashboard_gunicorn: "true"
+archivematica_src_am_multi_venvs: "yes"
+
+# reset setup vars, commented out here, uncomment if needed
+#archivematica_src_reset_am_all: "true"
+#archivematica_src_reset_ss_db: "true"
+
+# elasticsearch role
+
+elasticsearch_version: "1.7.5"
+elasticsearch_apt_java_package: "oracle-java8-installer"
+elasticsearch_java_home: "/usr/lib/jvm/java-8-oracle"
+elasticsearch_heap_size: "640m"
+elasticsearch_max_open_files: "65535"
+elasticsearch_node_max_local_storage_nodes: "1"
+elasticsearch_index_mapper_dynamic: "true"
+elasticsearch_memory_bootstrap_mlockall: "true"
+elasticsearch_install_java: "true"
+elasticsearch_thread_pools:
+  - "threadpool.bulk.type: fixed"
+  - "threadpool.bulk.size: 50"
+  - "threadpool.bulk.queue_size: 1000"
+
+# percona role
+
+mysql_root_password: "U6ygtjCHQ84NuyDk"


### PR DESCRIPTION
This PR request adds Vagrantfiles (and supporting ansible stuff) to create virtualbox archivematica  Ubuntu trusty and CentOS 7 VMs. 
The Vagrantfiles are confirmed to create working AM qa/1.6.x SS qa/0.x (0.10.x) instances. 
The PR is marked as "work-in-progress" because the required PRs in the related projects - [ansible-archivematica-src PR104](https://github.com/artefactual-labs/ansible-archivematica-src/pull/104), [SS PR175](https://github.com/artefactual/archivematica-storage-service/pull/175), [AM PR578](https://github.com/artefactual/archivematica/pull/578) - are not yet merged. For this reason, the ansible `requirements.txt` files specifies branch `dev/pkg-deps-in-src-repo-ub-rh` for the ansible-archivematica-src role, and the `vars-singlenode.yml` specify AM and SS branch `dev/deployment-osdeps-ub-rh`. These branches need to be changed once the mentioned PRs in related projects are merged. 
