### PR TITLE
pb am: use stable/1.6.x branch of ansible role

### DIFF
--- a/playbooks/archivematica/.gitignore
+++ b/playbooks/archivematica/.gitignore
@@ -1,3 +1,4 @@
 /roles
 /.vagrant
 /src
+*.retry

--- a/playbooks/archivematica/requirements.yml
+++ b/playbooks/archivematica/requirements.yml
@@ -16,7 +16,10 @@
   version: "master"
   name: "nginx"
 
-- src: "https://github.com/artefactual-labs/ansible-role-archivematica-src"
-  version: "master"
+- src: "https://github.com/artefactual-labs/ansible-archivematica-src"
+  version: "stable/1.6.x"
   name: "archivematica-src"
   
+- src: "https://github.com/artefactual-labs/ansible-clamav"
+  version: "master"
+  name: "clamav"

--- a/playbooks/archivematica/singlenode.yml
+++ b/playbooks/archivematica/singlenode.yml
@@ -32,6 +32,11 @@
       tags:
         - "gearman"
 
+    - role: "clamav"
+      become: "yes"
+      tags:
+        - "clamav"
+
     - role: "archivematica-src"
       become: "yes"
       tags:

--- a/playbooks/archivematica/vars-singlenode-1.6.yml
+++ b/playbooks/archivematica/vars-singlenode-1.6.yml
@@ -7,7 +7,7 @@ archivematica_src_am_version: "stable/1.6.x"
 archivematica_src_ss_version: "stable/0.10.x"
 archivematica_src_ss_gunicorn: "true"
 archivematica_src_am_dashboard_gunicorn: "true"
-archivematica_src_externals_repo: "http://packages.archivematica.org/1.6.x/ubuntu-externals"
+archivematica_src_am_multi_venvs: "true"
 
 # percona role
 
@@ -15,7 +15,7 @@ mysql_root_password: "ChangeThisai6eiN"
 
 # elasticsearch role
 
-elasticsearch_version: "1.7.5"
+elasticsearch_version: "1.7.6"
 elasticsearch_apt_java_package: "oracle-java8-installer"
 elasticsearch_java_home: "/usr/lib/jvm/java-8-oracle"
 elasticsearch_heap_size: "640m"


### PR DESCRIPTION
Use stable/1.6.x branch of [ansible-archivematica-src ansible role](https://github.com/artefactual-labs/ansible-archivematica-src) instead of old master branch, to deploy latest archivematica stable/1.6.x and storage service stable/0.10.x 
Tested and working ok.