### PR TITLE
Add prefix to role names (ansible-galaxy 2.3 bug)

### DIFF
--- a/playbooks/archivematica/requirements.yml
+++ b/playbooks/archivematica/requirements.yml
@@ -2,24 +2,24 @@
 
 - src: "https://github.com/artefactual-labs/ansible-elasticsearch"
   version: "master"
-  name: "elasticsearch"
+  name: "artefactual.elasticsearch"
 
 - src: "https://github.com/artefactual-labs/ansible-percona"
   version: "master"
-  name: "percona"
+  name: "artefactual.percona"
 
 - src: "https://github.com/artefactual-labs/ansible-gearman"
   version: "master"
-  name: "gearman"
+  name: "artefactual.gearman"
 
 - src: "https://github.com/artefactual-labs/ansible-nginx"
   version: "master"
-  name: "nginx"
+  name: "artefactual.nginx"
 
 - src: "https://github.com/artefactual-labs/ansible-archivematica-src"
   version: "stable/1.6.x"
-  name: "archivematica-src"
+  name: "artefactual.archivematica-src"
   
 - src: "https://github.com/artefactual-labs/ansible-clamav"
   version: "master"
-  name: "clamav"
+  name: "artefactual.clamav"

--- a/playbooks/archivematica/singlenode.yml
+++ b/playbooks/archivematica/singlenode.yml
@@ -17,27 +17,27 @@
 
   roles:
 
-    - role: "elasticsearch"
+    - role: "artefactual.elasticsearch"
       become: "yes"
       tags:
         - "elasticsearch"
 
-    - role: "percona"
+    - role: "artefactual.percona"
       become: "yes"
       tags:
         - "percona"
 
-    - role: "gearman"
+    - role: "artefactual.gearman"
       become: "yes"
       tags:
         - "gearman"
 
-    - role: "clamav"
+    - role: "artefactual.clamav"
       become: "yes"
       tags:
         - "clamav"
 
-    - role: "archivematica-src"
+    - role: "artefactual.archivematica-src"
       become: "yes"
       tags:
         - "archivematica-src"

--- a/playbooks/archivematica/vars-singlenode-qa.yml
+++ b/playbooks/archivematica/vars-singlenode-qa.yml
@@ -7,10 +7,11 @@ archivematica_src_am_version: "qa/1.x"
 archivematica_src_ss_version: "qa/0.x"
 archivematica_src_ss_gunicorn: "true"
 archivematica_src_am_dashboard_gunicorn: "true"
+archivematica_src_am_multi_venvs: "true"
 
 # elasticsearch role
 
-elasticsearch_version: "1.7.5"
+elasticsearch_version: "1.7.6"
 elasticsearch_apt_java_package: "oracle-java8-installer"
 elasticsearch_java_home: "/usr/lib/jvm/java-8-oracle"
 elasticsearch_heap_size: "640m"


### PR DESCRIPTION
Add prefix to role names to work around ansible-galaxy 2.3 bug.

ansible-galaxy 2.3.0 has a bug that causes template files with names
that coincide with the role name to be fetched incorrectly (e.g.,
instead of roles/elasticsearch/templates/elasticsearch.default.j2 the
file is downloaded as roles/elasticsearch/templates/.default.j2)
causing the playbook to fail.

Refs. 11123