### PR TITLE
playbooks: add atom-centos7 playbook folder

### DIFF
--- a/playbooks/atom-centos7/README.md
+++ b/playbooks/atom-centos7/README.md
@@ -1,0 +1,43 @@
+# AtoM Playbook
+
+The provided playbook installs AtoM on a local Vagrant virtual machine.
+
+## Requirements
+
+- Vagrant 1.8.1 or newer
+- Ansible 2.0.1 or newer
+
+## How to use
+
+Dowload the Ansible roles
+
+    $ ansible-galaxy install -f -p roles/ -r requirements.yml
+
+Create the virtual machine and provision it:
+
+    $ vagrant up
+
+To ssh to the VM, run:
+
+    $ vagrant ssh
+
+If you want to forward your SSH agent too, run:
+
+    $ vagrant ssh -- -A
+
+To (re-)provision the VM, using Vagrant:
+
+    $ vagrant provision
+
+To (re-)provision the VM, using Ansible commands directly:
+
+    $ ansible-playbook singlenode.yml
+        --inventory-file=".vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory" \
+        --user="vagrant" \
+        --private-key=".vagrant/machines/atom-local/virtualbox/private_key" \
+        --extra-vars="atom_dir=/vagrant/src atom_environment_type=development" \
+        --verbose
+
+To (re-)provision the VM, passing your own arguments to `Ansible`:
+
+    $ ANSIBLE_ARGS="--tags=mysql,atom" vagrant provision

--- a/playbooks/atom-centos7/Vagrantfile
+++ b/playbooks/atom-centos7/Vagrantfile
@@ -1,0 +1,49 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # note the official centos box doesn't have guest additions
+  # using geerlingguy box instead ( to have synced folders ) 
+  config.vm.box = ENV.fetch("VAGRANT_BOX", "centos/7")
+
+  {
+    "atom-local-centos7" => {
+      "ip" => "192.168.168.201",
+      "memory" => "4096",
+      "cpus" => "2",
+    },
+  }.each do |short_name, properties|
+
+    # Define guest
+    config.vm.define short_name do |host|
+      host.vm.network "private_network", ip: properties.fetch("ip")
+    end
+
+    # Set the amount of RAM and virtual CPUs for the virtual machine
+    config.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", properties.fetch("memory")]
+      vb.customize ["modifyvm", :id, "--cpus", properties.fetch("cpus")]
+    end
+
+  end
+
+  # Make the project root available to the guest VM
+  config.vm.synced_folder '.', '/vagrant'
+
+  # Ansible provisioning
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "./singlenode.yml"
+    ansible.host_key_checking = false
+    ansible.extra_vars = {
+      "atom_environment_type" => "development",
+      "atom_flush_data" => "yes"
+    }
+    ansible.verbose = 'v'
+    # accept multiple arguments, separated by colons
+    ansible.raw_arguments = ENV['ANSIBLE_ARGS'].to_s.split(':')
+  end
+end

--- a/playbooks/atom-centos7/requirements.yml
+++ b/playbooks/atom-centos7/requirements.yml
@@ -1,0 +1,16 @@
+---
+
+- src: "https://github.com/artefactual-labs/ansible-nginx"
+  version: "master"
+  name: "artefactual.nginx"
+  path: "roles/"
+
+- src: "https://github.com/artefactual-labs/ansible-atom"
+  version: "dev/centos-support"
+  name: "artefactual.atom"
+  path: "roles/"
+
+- src: "https://github.com/geerlingguy/ansible-role-mysql"
+  version: "master"
+  name: "geerlingguy.mysql"
+  path: "roles/"

--- a/playbooks/atom-centos7/singlenode.yml
+++ b/playbooks/atom-centos7/singlenode.yml
@@ -1,0 +1,21 @@
+---
+- hosts: "atom-local-centos7"
+  
+  pre_tasks:
+    - include_vars: "vars-singlenode.yml"
+      tags:
+        - "always"
+
+  roles:
+    - role: "geerlingguy.mysql"
+      become: "yes"
+      tags:
+        - "mysql"
+    - role: "artefactual.nginx"
+      become: "yes"
+      tags:
+        - "nginx"
+    - role: "artefactual.atom"
+      become: "yes"
+      tags:
+        - "atom"

--- a/playbooks/atom-centos7/vars-singlenode.yml
+++ b/playbooks/atom-centos7/vars-singlenode.yml
@@ -1,0 +1,103 @@
+---
+
+# PLEASE NOTE THAT THE PASSWORD VALUES USED HERE ARE NOT SAFE
+
+#
+# atom role
+#
+atom_path: "/usr/share/nginx/atom"
+atom_repository_url: "https://github.com/artefactual/atom.git"
+atom_repository_version: "qa/2.4.x"
+atom_config_db_hostname: "127.0.0.1"
+atom_config_db_name: "atom"
+atom_config_db_username: "atom-user"
+atom_config_db_password: "ATOMPASSWORD"
+atom_config_db_port: "3306"
+atom_config_db_priv: "{{ atom_config_db_name }}.*:ALL,GRANT"
+atom_es_host: "127.0.0.1"
+atom_es_port: "9200"
+
+# Centos/Redhat use "nginx" instead of "www-data" user
+atom_user: "nginx"
+atom_group: "nginx"
+atom_pool_listen_owner: "{{ atom_user }}"
+atom_pool_listen_group: "{{ atom_group }}"
+
+
+#
+# nginx role
+#
+
+nginx_configs:
+  atom_backend:
+    - upstream atom {
+        server unix:/var/run/php-fpm.atom.sock;
+      }
+
+nginx_sites:
+  atom:
+    - listen 80
+    - set $atom_path {{ atom_path }}
+    - root $atom_path
+    - server_name _
+    - client_max_body_size 72M
+    - location / { try_files $uri /index.php?$args; }
+    - location ~ /\. {
+        deny all;
+        return 404;
+      }
+    - location ~* (\.yml|\.ini|\.tmpl)$ {
+        deny all;
+        return 404;
+      }
+    - location ~* /(?:uploads|files)/.*\.php$ {
+        deny all;
+        return 404;
+      }
+    - location ~* /uploads/r/(.*)/conf/ { }
+    - location ~* ^/uploads/r/(.*)$ {
+        include /etc/nginx/fastcgi_params;
+        set $index /index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$index;
+        fastcgi_param SCRIPT_NAME $index;
+        fastcgi_pass atom;
+      }
+    - location ~ ^/private/(.*)$ {
+        internal;
+        alias $atom_path/$1;
+      }
+    - location ~ ^/(index|qubit_dev)\.php(/|$) {
+        include /etc/nginx/fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        fastcgi_pass atom;
+      }
+    - location ~* \.php$ {
+        deny all;
+        return 404;
+      }
+
+#
+# elasticsearch role
+#
+
+elasticsearch_version: "1.7.5"
+elasticsearch_heap_size: "640m"
+
+#
+# percona role
+#
+
+mysql_databases:
+  - name: "{{ atom_config_db_name }}"
+    collation: "utf8_general_ci"
+    encoding: "utf8"
+
+mysql_users:
+  - name: "{{ atom_config_db_username }}"
+    password: "{{ atom_config_db_password }}"
+    priv: "{{ atom_config_db_priv }}"
+    host: "{{ atom_config_db_hostname }}"
+
+mysql_root_password: "MYSQLROOTPASSWORD"
+mysql_bind_address: "127.0.0.1"


### PR DESCRIPTION
Added support for Centos 7 / RHEL 7
 
The requirements.xml file uses the branch from artefactual-labs/ansible-atom#15

A recording of a playbook run can be seen here:

https://asciinema.org/a/QaV86XImZ5cf8D50aEYTlPMCp