### PR TITLE
Support vagrant on windows

### DIFF
--- a/playbooks/archivematica/README.md
+++ b/playbooks/archivematica/README.md
@@ -10,6 +10,11 @@ Deploy](docs/digital-ocean-install-example.rst) document.
 - Vagrant 1.7 or newer
 - Ansible 2.1.2 or newer
 
+If you are using Windows, note that symlinks are not created by default and this will cause the "vagrant provision" step to fail. To enable symlink creation, do one of the following:
+
+- Run the following commands as a Windows Administrator; or
+- Have a Windows Administrator add you to the "Create symbolic links" policy in the "Local Security Policy" (located under "Local Policies" then "User Rights Assignment") and then log out and log back in for the policy to take effect.
+
 ## How to use
 
 1. Create the virtual machine and provision it:

--- a/playbooks/archivematica/README.md
+++ b/playbooks/archivematica/README.md
@@ -12,27 +12,22 @@ Deploy](docs/digital-ocean-install-example.rst) document.
 
 ## How to use
 
-1. Download the Ansible roles:
-  ```
-  $ ansible-galaxy install -f -p roles/ -r requirements.yml
-  ```
-
-2. Create the virtual machine and provision it:
+1. Create the virtual machine and provision it:
   ```
   $ vagrant up
   ```
 
-3. To ssh to the VM, run:
+2. To ssh to the VM, run:
   ```
   $ vagrant ssh
   ```
 
-4. If you want to forward your SSH agent too, run:
+3. If you want to forward your SSH agent too, run:
   ```
   $ vagrant ssh -- -A
   ```
 
-5. To (re-)provision the VM, run:
+4. To (re-)provision the VM, run:
     * Using vagrant:
         ```
         $ vagrant provision
@@ -53,7 +48,7 @@ Deploy](docs/digital-ocean-install-example.rst) document.
            -v
         ```
 
-6. The ansible playbook `singlenode.yml` specified in the Vagrantfile will provision using stable branches of archivematica. To provision using the qa 1.x/0.x branches, replace "vars-singlenode-1.6.yml" with "vars-singlenode-qa.yml" in `singlenode.yml`. You can also modify create a custom vars file and pass it instead (to modify role variables to deploy custom branches, etc.)  
+5. The ansible playbook `singlenode.yml` specified in the Vagrantfile will provision using stable branches of archivematica. To provision using the qa 1.x/0.x branches, replace "vars-singlenode-1.6.yml" with "vars-singlenode-qa.yml" in `singlenode.yml`. You can also modify create a custom vars file and pass it instead (to modify role variables to deploy custom branches, etc.)  
 
 
 For more archivematica development information, see: https://wiki.archivematica.org/Getting_started

--- a/playbooks/archivematica/Vagrantfile
+++ b/playbooks/archivematica/Vagrantfile
@@ -1,10 +1,23 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+module OS
+    # Try detecting Windows
+    def OS.windows?
+        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+    end
+end
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  #Switch to ansible_local for Windows hosts
+  provisioner = :ansible
+  if OS.windows?
+    provisioner = :ansible_local
+  end
 
   config.vm.box = ENV.fetch("VAGRANT_BOX", "ubuntu/trusty64")
 
@@ -39,12 +52,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #NOTE: Can't put these in singlenode.yml since ansible-galaxy runs before ansible-playbook.
 
   # Ansible provisioning
-  config.vm.provision :ansible do |ansible|
+  config.vm.provision provisioner do |ansible|
     ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force"
     ansible.galaxy_role_file = "requirements.yml"
     ansible.galaxy_roles_path = "roles/"
     ansible.playbook = "./singlenode.yml"
-    ansible.host_key_checking = false
+    if provisioner == :ansible
+      ansible.host_key_checking = false
+    end
     ansible.extra_vars = {
       "archivematica_src_dir" => "/vagrant/src",
       "archivematica_src_environment_type" => "development",

--- a/playbooks/archivematica/Vagrantfile
+++ b/playbooks/archivematica/Vagrantfile
@@ -33,8 +33,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Make the project root available to the guest VM
   config.vm.synced_folder '.', '/vagrant'
 
+  #git package required for ansible-galaxy when fetching git sources
+  config.vm.provision "shell", inline: "apt-get update"
+  config.vm.provision "shell", inline: "apt-get install -y git"
+  #NOTE: Can't put these in singlenode.yml since ansible-galaxy runs before ansible-playbook.
+
   # Ansible provisioning
   config.vm.provision :ansible do |ansible|
+    ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force"
+    ansible.galaxy_role_file = "requirements.yml"
+    ansible.galaxy_roles_path = "roles/"
     ansible.playbook = "./singlenode.yml"
     ansible.host_key_checking = false
     ansible.extra_vars = {

--- a/playbooks/archivematica/Vagrantfile
+++ b/playbooks/archivematica/Vagrantfile
@@ -2,10 +2,10 @@
 # vi: set ft=ruby :
 
 module OS
-    # Try detecting Windows
-    def OS.windows?
-        (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
-    end
+  # Try detecting Windows
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
 end
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!


### PR DESCRIPTION
This branch makes 2 changes to the Vagrantfile to enable it to work on a Windows host. 

The first is to run ansible-galaxy inside the guest OS using Vagrant rather than running it manually in the host OS, since one cannot run ansible-galaxy in Windows typically. I think this change is actually useful to everyone, so I haven't wrapped it in Windows detection. In the event that a Linux user does do ansible-galaxy manually before running 'vagrant up' or 'vagrant provision', it shouldn't matter as it's idempotent. (As part of this change, it's necessary to install Git in the guest OS since it's needed when ansible-galaxy fetches from Git sources.)

The second change is to detect Windows and to change from :ansible to :ansible_local in that case, and to exclude the host checking option in that case since it's incompatible with ansible_local. 

These are pretty simple changes which shouldn't make any real difference for anyone on a non-Windows system.

It's worth noting (here, there, everywhere) that Vagrant will only work on Windows with 'deploy-pub' if the user is running as an Administrator or if the user has the "create symbolic links" privilege granted via  "Local Security Policy" (ie secpol.msc). I think I might need to revise my commit message a bit to mention the part about opening "Local Security Policy" or secpol.msc, but before I do that...I'll just see what you all think!