### PR TITLE
AtoM stable/2.4.x and qa/2.5.x changes

### DIFF
--- a/playbooks/atom-trusty/vars-singlenode.yml
+++ b/playbooks/atom-trusty/vars-singlenode.yml
@@ -8,7 +8,7 @@
 
 atom_path: "/usr/share/nginx/atom"
 atom_repository_url: "https://github.com/artefactual/atom.git"
-atom_repository_version: "qa/2.3.x"
+atom_repository_version: "stable/2.4.x"
 atom_config_db_hostname: "127.0.0.1"
 atom_config_db_name: "atom"
 atom_config_db_username: "atom-user"
@@ -78,7 +78,7 @@ nginx_sites:
 # elasticsearch role
 #
 
-elasticsearch_version: "1.7.5"
+elasticsearch_version: "1.7.6"
 elasticsearch_heap_size: "640m"
 
 #

--- a/playbooks/atom-xenial/requirements.yml
+++ b/playbooks/atom-xenial/requirements.yml
@@ -1,8 +1,8 @@
 ---
 
-- src: "https://github.com/artefactual-labs/ansible-elasticsearch"
+- src: "https://github.com/elastic/ansible-elasticsearch"
   version: "master"
-  name: "artefactual.elasticsearch"
+  name: "elastic.elasticsearch"
   path: "roles/"
 
 - src: "https://github.com/artefactual-labs/ansible-percona"

--- a/playbooks/atom-xenial/singlenode.yml
+++ b/playbooks/atom-xenial/singlenode.yml
@@ -9,7 +9,7 @@
 
   roles:
 
-    - role: "artefactual.elasticsearch"
+    - role: "elastic.elasticsearch"
       become: "yes"
       tags:
         - "elasticsearch"

--- a/playbooks/atom-xenial/vars-singlenode.yml
+++ b/playbooks/atom-xenial/vars-singlenode.yml
@@ -8,7 +8,7 @@
 
 atom_path: "/usr/share/nginx/atom"
 atom_repository_url: "https://github.com/artefactual/atom.git"
-atom_repository_version: "qa/2.3.x"
+atom_repository_version: "qa/2.5.x"
 atom_config_db_hostname: "127.0.0.1"
 atom_config_db_name: "atom"
 atom_config_db_username: "atom-user"
@@ -78,8 +78,11 @@ nginx_sites:
 # elasticsearch role
 #
 
-elasticsearch_version: "1.7.5"
-elasticsearch_heap_size: "640m"
+es_instance_name: "atom_node"
+es_heap_size: "640m"
+es_allow_downgrades: true
+es_major_version: "5.x"
+es_version: "5.5.2"
 
 #
 # percona role


### PR DESCRIPTION
- Change branch to stable/2.4.x and use ES 1.7.6 in atom-trusty
- Upgrade to AtoM qa/2.5.x and ES 5.x in atom-xenial, use Elastic
  role for ansible-elasticsearch