### PR TITLE
Add singlenode-indexless.yml playbook to AM envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant/
+*.retry

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -1,0 +1,52 @@
+---
+- hosts: "am-local-centos7"
+
+  pre_tasks:
+
+    - fail:
+      msg: "This playbook is temporarily disabled, see https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/25 for more details. Uncomment this task if you want to test."
+
+    - include_vars: "vars-singlenode.yml"
+      tags:
+        - "always"
+
+    - name: "Set SELinux to Permissive"
+      command: "setenforce Permissive"      
+      become: "yes"
+
+    - name: "Enable epel repository"
+      yum:
+        name: "epel-release"
+        state: "latest"
+      become: "yes"
+
+    - name: "Install mariadb-server, gearman"
+      yum:
+        name: "{{ item }}"
+        state: "latest"
+      with_items:
+        - "mariadb-server"
+        - "gearmand"
+      become: "yes"
+
+    - name: "Enable and start mariadb, gearman servers"   
+      service:
+        name: "{{ item }}"
+        state: "started"
+        enabled: "yes"
+      with_items:
+        - "mariadb"
+        - "gearmand"
+      become: "yes"
+
+  roles:
+    - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
+    - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
+    - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
+
+  tasks:
+    - name: "change home dir perms (to make transfer source visible)"
+      command: "chmod 755 $HOME" 
+      tags: "homeperms"
+      become: "no"
+

--- a/playbooks/archivematica-xenial/singlenode-indexless.yml
+++ b/playbooks/archivematica-xenial/singlenode-indexless.yml
@@ -1,0 +1,41 @@
+---
+- hosts: "am-local"
+
+  pre_tasks:
+
+    - fail:
+        msg: "This playbook is temporarily disabled, see https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/25 for more details."
+
+    - include_vars: "vars-singlenode-qa.yml"
+      tags:
+        - "always"
+
+    - name: "Install packages for development convenience"
+      apt:
+        pkg: "{{ item }}"
+        state: "latest"
+      with_items:
+        - "fish"
+      become: "yes"
+
+  roles:
+
+    - role: "artefactual.percona"
+      become: "yes"
+      tags:
+        - "percona"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+      tags:
+        - "gearman"
+
+    - role: "artefactual.clamav"
+      become: "yes"
+      tags:
+        - "clamav"
+
+    - role: "artefactual.archivematica-src"
+      become: "yes"
+      tags:
+        - "archivematica-src"

--- a/playbooks/archivematica/singlenode-indexless.yml
+++ b/playbooks/archivematica/singlenode-indexless.yml
@@ -1,0 +1,41 @@
+---
+- hosts: "am-local"
+
+  pre_tasks:
+
+    - fail:
+      msg: "This playbook is temporarily disabled, see https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/25 for more details. Uncomment this task if you want to test."
+
+    - include_vars: "vars-singlenode-qa.yml"
+      tags:
+        - "always"
+
+    - name: "Install packages for development convenience"
+      apt:
+        pkg: "{{ item }}"
+        state: "latest"
+      with_items:
+        - "fish"
+      become: "yes"
+
+  roles:
+
+    - role: "artefactual.percona"
+      become: "yes"
+      tags:
+        - "percona"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+      tags:
+        - "gearman"
+
+    - role: "artefactual.clamav"
+      become: "yes"
+      tags:
+        - "clamav"
+
+    - role: "artefactual.archivematica-src"
+      become: "yes"
+      tags:
+        - "archivematica-src"


### PR DESCRIPTION
The playbook was added to all the AM environments (archivematica, archivematica-xenial and archivematica-centos7). It fails with the following error to make sure the user is using this playbook knowing that deployin AM without Elasticsearch it's work in progress.

> This playbook is temporarily disabled, see https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/25 for more details. Uncomment this task if you want to test."

Ref: https://github.com/artefactual-labs/archivematica-acceptance-tests/pull/25

fixes #44.