### PR TITLE
playbooks/archivematica and archivematica-xenial: install openjdk instead of oracle java

### DIFF
--- a/playbooks/archivematica-xenial/vars-singlenode-1.6.yml
+++ b/playbooks/archivematica-xenial/vars-singlenode-1.6.yml
@@ -16,8 +16,10 @@ mysql_root_password: "MYSQLROOTPASSWORD"
 # elasticsearch role
 
 elasticsearch_version: "1.7.6"
-elasticsearch_apt_java_package: "oracle-java8-installer"
-elasticsearch_java_home: "/usr/lib/jvm/java-8-oracle"
+elasticsearch_apt_java_package: "openjdk-8-jre-headless"
+elasticsearch_apt_repos: []
+elasticsearch_apt_dependencies: []
+elasticsearch_java_home: "/usr/lib/jvm/java-8-openjdk-amd64"
 elasticsearch_heap_size: "640m"
 elasticsearch_max_open_files: "65535"
 elasticsearch_node_max_local_storage_nodes: "1"

--- a/playbooks/archivematica/vars-singlenode-1.6.yml
+++ b/playbooks/archivematica/vars-singlenode-1.6.yml
@@ -16,8 +16,10 @@ mysql_root_password: "ChangeThisai6eiN"
 # elasticsearch role
 
 elasticsearch_version: "1.7.6"
-elasticsearch_apt_java_package: "oracle-java8-installer"
-elasticsearch_java_home: "/usr/lib/jvm/java-8-oracle"
+elasticsearch_apt_java_package: "openjdk-7-jre-headless"
+elasticsearch_apt_repos: []
+elasticsearch_apt_dependencies: []
+elasticsearch_java_home: "/usr/lib/jvm/java-7-openjdk-amd64"
 elasticsearch_heap_size: "640m"
 elasticsearch_max_open_files: "65535"
 elasticsearch_node_max_local_storage_nodes: "1"


### PR DESCRIPTION
Oracle repository seems to be no longer providing the
oracle-java8-installer package required by the
ansible-elasticsearch role. Install openjdk 7
provided by Ubuntu trusty standard repository instead.
Ref. https://github.com/artefactual-labs/ansible-elasticsearch/issues/3