### PR TITLE
Enable ansible allow_world_readable_tmpfiles

### DIFF
--- a/playbooks/archivematica/ansible.cfg
+++ b/playbooks/archivematica/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 nocows = 1
+allow_world_readable_tmpfiles = 1


### PR DESCRIPTION
Else, the playbook fails to become an unprivileged user

Refs: http://docs.ansible.com/ansible/latest/user_guide/become.html#becoming-an-unprivileged-user