### PR TITLE
Add details to installation instructions

### DIFF
--- a/playbooks/archivematica/docs/digital-ocean-install-example.rst
+++ b/playbooks/archivematica/docs/digital-ocean-install-example.rst
@@ -15,7 +15,9 @@ created a new droplet. The following URL may be useful for accomplishing this.
 
 - https://www.digitalocean.com/community/tutorials/how-to-create-your-first-digitalocean-droplet-virtual-server
 
-In this example, we are using Ubuntu 14.04.
+Note that Digital Ocean (using Ubuntu 16.04 at any rate) only installs Python 3 by default. You will need to install python 2.7 after you set up your droplet. 
+
+In this example, we are using Ubuntu 14.04. These instructions have also worked with Ubuntu with 16.04. 
 
 
 1. Clone the git repository that contains the Ansible configuration files which
@@ -82,6 +84,10 @@ The ``user.yml`` file creates a user called "artefactual" on the droplet, adds
 your public key (assumed to be in ``~/.ssh/id_rsa.pub``) to the droplet, and
 allows the artefactual user to run commands using ``sudo`` without a password.
 Choose a different username than "artefactual" if you want.
+
+To run the user playbook, use the command: 
+
+    $ ansible-playbook user.yml
 
 8. Modify the ``hosts`` file to use the appropriate (e.g., ``artefactual``) user::
 

--- a/playbooks/archivematica/docs/digital-ocean-install-example.rst
+++ b/playbooks/archivematica/docs/digital-ocean-install-example.rst
@@ -1,7 +1,7 @@
-How to Deploy Archivematica to a Digital Ocean Droplet
+How to Deploy Archivematica to a DigitalOcean Droplet
 ================================================================================
 
-This document describes how to deploy Archivematica to a Digital Ocean droplet
+This document describes how to deploy Archivematica to a DigitalOcean droplet
 (i.e., virtual private server, VPS).  It assumes that you have basic
 proficiency with the Unix command-line and that you have the following
 installed.
@@ -10,12 +10,12 @@ installed.
 - Python
 - Ansible (http://docs.ansible.com/ansible/intro_installation.html)
 
-We are also assuming that you have a Digital Ocean account and that you have
+We are also assuming that you have a DigitalOcean account and that you have
 created a new droplet. The following URL may be useful for accomplishing this.
 
 - https://www.digitalocean.com/community/tutorials/how-to-create-your-first-digitalocean-droplet-virtual-server
 
-Note that Digital Ocean (using Ubuntu 16.04 at any rate) only installs Python 3 by default. You will need to install python 2.7 after you set up your droplet. 
+Note that DigitalOcean (using Ubuntu 16.04 at any rate) only installs Python 3 by default. You will need to install Python 2.7 after you set up your droplet. 
 
 In this example, we are using Ubuntu 14.04. These instructions have also worked with Ubuntu with 16.04. 
 


### PR DESCRIPTION
Added note about Digital Ocean needing Python 2.7 installed as a precondition. 
Added specific command to be used in step 7. 
This addresses issues in #72