### PR TITLE
pb atom-trusty: remove percona-client role

### DIFF
--- a/playbooks/atom-trusty/requirements.yml
+++ b/playbooks/atom-trusty/requirements.yml
@@ -10,11 +10,6 @@
   name: "artefactual.percona"
   path: "roles/"
 
-- src: "https://github.com/artefactual-labs/ansible-percona-client"
-  version: "master"
-  name: "artefactual.percona-client"
-  path: "roles/"
-
 - src: "https://github.com/artefactual-labs/ansible-memcached"
   version: "master"
   name: "artefactual.memcached"

--- a/playbooks/atom-trusty/singlenode.yml
+++ b/playbooks/atom-trusty/singlenode.yml
@@ -19,11 +19,6 @@
       tags:
         - "percona"
 
-    - role: "artefactual.percona-client"
-      become: "yes"
-      tags:
-        - "percona-client"
-
     - role: "artefactual.memcached"
       become: "yes"
       tags:

--- a/playbooks/atom-xenial/requirements.yml
+++ b/playbooks/atom-xenial/requirements.yml
@@ -10,11 +10,6 @@
   name: "artefactual.percona"
   path: "roles/"
 
-- src: "https://github.com/artefactual-labs/ansible-percona-client"
-  version: "master"
-  name: "artefactual.percona-client"
-  path: "roles/"
-
 - src: "https://github.com/artefactual-labs/ansible-memcached"
   version: "master"
   name: "artefactual.memcached"


### PR DESCRIPTION
This is not required as percona role installs both server and client. It was also
causing issues as this role is not updated and was preventing the
server to start.

Fixes #74