### PR TITLE
Add MySQL config to vars- files

### DIFF
--- a/playbooks/archivematica-xenial/vars-singlenode-qa.yml
+++ b/playbooks/archivematica-xenial/vars-singlenode-qa.yml
@@ -29,4 +29,15 @@ elasticsearch_thread_pools:
 
 # percona role
 
+mysql_databases:
+  - name: "{{ archivematica_src_am_db_name }}"
+    collation: "utf8_general_ci"
+    encoding: "utf8"
+
+mysql_users:
+  - name: "{{ archivematica_src_am_db_user }}"
+    pass: "{{ archivematica_src_am_db_password }}"
+    priv: "{{ archivematica_src_am_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_am_db_host }}"
+
 mysql_root_password: "MYSQLROOTPASSWORD"

--- a/playbooks/archivematica/vars-singlenode-qa.yml
+++ b/playbooks/archivematica/vars-singlenode-qa.yml
@@ -29,4 +29,15 @@ elasticsearch_thread_pools:
 
 # percona role
 
+mysql_databases:
+  - name: "{{ archivematica_src_am_db_name }}"
+    collation: "utf8_general_ci"
+    encoding: "utf8"
+
+mysql_users:
+  - name: "{{ archivematica_src_am_db_user }}"
+    pass: "{{ archivematica_src_am_db_password }}"
+    priv: "{{ archivematica_src_am_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_am_db_host }}"
+
 mysql_root_password: "U6ygtjCHQ84NuyDk"


### PR DESCRIPTION
Adds `mysql_databases` and `mysql_users` keys to the `-qa`-suffixedvars files archivematica-xenial/vars-singlenode-qa.yml and archivematica/vars-singlenode-qa.yml.