### PR TITLE
fix CentOS playbook

### DIFF
--- a/playbooks/archivematica-centos7/README.md
+++ b/playbooks/archivematica-centos7/README.md
@@ -7,8 +7,8 @@ Deploy](docs/digital-ocean-install-example.rst) document.
 
 ## Requirements
 
-- Vagrant 1.9.2 or newer (note that vagrant 1.9.1 has a bug when restarting network services in RHEL https://github.com/mitchellh/vagrant/pull/8148)
-- Ansible 2.2 or newer
+- Vagrant 1.9.2 or newer (note that vagrant 1.9.1 has a bug when restarting network services in RHEL https://github.com/mitchellh/vagrant/pull/8148). Vagrant has changed its image repository URLs, so when using an old Vagrant version, see https://github.com/hashicorp/vagrant/issues/9442
+- Ansible 2.4 or newer (needed by jdauphant/ansible-role-nginx)
 
 ## How to use
 

--- a/playbooks/archivematica-centos7/requirements.yml
+++ b/playbooks/archivematica-centos7/requirements.yml
@@ -15,3 +15,7 @@
 - src: "https://github.com/artefactual-labs/ansible-archivematica-src"
   version: "stable/1.7.x"
   name: "artefactual.archivematica-src"
+
+- src: "https://github.com/artefactual-labs/ansible-gearman.git"
+  version: "dev/centos-support"
+  name: "artefactual.gearman"

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -10,6 +10,16 @@
       tags:
         - "always"
 
+    - name: "Install some python packages"
+      become: "yes"
+      yum:
+         name: "{{ item }}"
+         state: "present"
+      with_items:
+        - libsemanage-python
+        - policycoreutils-python
+        - MySQL-python
+
     - name: "Set SELinux to Permissive"
       command: "setenforce Permissive"      
       become: "yes"

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -30,23 +30,21 @@
         state: "latest"
       become: "yes"
 
-    - name: "Install mariadb-server, gearman"
+    - name: "Install mariadb-server"
       yum:
         name: "{{ item }}"
         state: "latest"
       with_items:
         - "mariadb-server"
-        - "gearmand"
       become: "yes"
 
-    - name: "Enable and start mariadb, gearman servers"   
+    - name: "Enable and start mariadb"   
       service:
         name: "{{ item }}"
         state: "started"
         enabled: "yes"
       with_items:
         - "mariadb"
-        - "gearmand"
       become: "yes"
 
     - name: "Make sure the MySQL databases are present"
@@ -70,6 +68,7 @@
 
   roles:
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
+    - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
     - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
     - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -39,6 +39,25 @@
         - "gearmand"
       become: "yes"
 
+    - name: "Make sure the MySQL databases are present"
+      mysql_db:
+        name: "{{ item.name }}"
+        collation: "{{ item.collation | default('utf8_general_ci') }}"
+        encoding: "{{ item.encoding | default('utf8') }}"
+        state: "present"
+      with_items: "{{ mysql_databases }}"
+      become: "yes"
+
+    - name: "Make sure the MySQL users are present"
+      mysql_user:
+        name: "{{ item.name }}"
+        password: "{{ item.pass | default('pass') }}"
+        priv: "{{ item.priv | default('*.*:ALL') }}"
+        state: "present"
+        host: "{{ item.host | default('localhost') }}"
+      with_items: "{{ mysql_users }}"
+      become: "yes"
+
   roles:
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
     - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -56,23 +56,21 @@
          state: "latest"
       become: "yes"
 
-    - name: "Install mariadb-server, gearman"
+    - name: "Install mariadb-server"
       yum:
         name: "{{ item }}"
         state: "latest"
       with_items:
         - "mariadb-server"
-        - "gearmand"
       become: "yes"
 
-    - name: "Enable and start mariadb, gearman servers"   
+    - name: "Enable and start mariadb"   
       service:
         name: "{{ item }}"
         state: "started"
         enabled: "yes"
       with_items:
         - "mariadb"
-        - "gearmand"
       become: "yes"
 
     - name: "Make sure the MySQL databases are present"
@@ -117,6 +115,7 @@
         when: "archivematica_src_search_enabled|bool",
       }
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
+    - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
     - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
     - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -65,6 +65,25 @@
         - "gearmand"
       become: "yes"
 
+    - name: "Make sure the MySQL databases are present"
+      mysql_db:
+        name: "{{ item.name }}"
+        collation: "{{ item.collation | default('utf8_general_ci') }}"
+        encoding: "{{ item.encoding | default('utf8') }}"
+        state: "present"
+      with_items: "{{ mysql_databases }}"
+      become: "yes"
+
+    - name: "Make sure the MySQL users are present"
+      mysql_user:
+        name: "{{ item.name }}"
+        password: "{{ item.pass | default('pass') }}"
+        priv: "{{ item.priv | default('*.*:ALL') }}"
+        state: "present"
+        host: "{{ item.host | default('localhost') }}"
+      with_items: "{{ mysql_users }}"
+      become: "yes"
+
   roles:
     - { role: "elastic.elasticsearch", 
         tags: ["elasticsearch"], 

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -7,6 +7,16 @@
       tags:
         - "always"
 
+    - name: "Install some python packages"
+      become: "yes"
+      yum:
+         name: "{{ item }}"
+         state: "present"
+      with_items:
+        - libsemanage-python
+        - policycoreutils-python
+        - MySQL-python
+
     - name: "SELinux: Allow nginx connections to Gunicorn"
       become: "yes"
       seboolean:

--- a/playbooks/archivematica-centos7/vars-singlenode.yml
+++ b/playbooks/archivematica-centos7/vars-singlenode.yml
@@ -28,3 +28,18 @@ es_restart_on_change: true
 es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: []
+
+# mariadb variables
+
+mysql_databases:
+  - name: "{{ archivematica_src_am_db_name }}"
+    collation: "utf8_general_ci"
+    encoding: "utf8"
+
+mysql_users:
+  - name: "{{ archivematica_src_am_db_user }}"
+    pass: "{{ archivematica_src_am_db_password }}"
+    priv: "{{ archivematica_src_am_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_am_db_host }}"
+
+mysql_root_password: "ChangeMe!"


### PR DESCRIPTION
These changes connect to issues #83 and #82 and install some python packages needed by the Vagrant CentOS image:

* The artefactual [ansible-gearman](https://github.com/artefactual-labs/ansible-gearman) role is used.
* The database and MySQL user is created on playbook.
*  `libsemanage-python`, `policycoreutils-python` and `MySQL-python` are installed.
