### PR TITLE
playbooks: add am-configure to AM deploys

### DIFF
--- a/playbooks/archivematica-centos7/vars-singlenode.yml
+++ b/playbooks/archivematica-centos7/vars-singlenode.yml
@@ -28,3 +28,14 @@ es_restart_on_change: true
 es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: []
+
+#AM configure vars
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_email: "admin@example.com"
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"

--- a/playbooks/archivematica-trusty/vars-singlenode-1.7.yml
+++ b/playbooks/archivematica-trusty/vars-singlenode-1.7.yml
@@ -43,3 +43,14 @@ mysql_users:
     host: "{{ archivematica_src_am_db_host }}"
 
 mysql_root_password: "ChangeMe!"
+
+#AM configure vars
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_email: "admin@example.com"
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"

--- a/playbooks/archivematica-trusty/vars-singlenode-qa.yml
+++ b/playbooks/archivematica-trusty/vars-singlenode-qa.yml
@@ -41,3 +41,14 @@ mysql_users:
     host: "{{ archivematica_src_am_db_host }}"
 
 mysql_root_password: "U6ygtjCHQ84NuyDk"
+
+#AM configure vars
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_email: "admin@example.com"
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"

--- a/playbooks/archivematica-xenial/vars-singlenode-1.7.yml
+++ b/playbooks/archivematica-xenial/vars-singlenode-1.7.yml
@@ -42,3 +42,14 @@ mysql_users:
     host: "{{ archivematica_src_am_db_host }}"
 
 mysql_root_password: "ChangeMe!"
+
+#AM configure vars
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_email: "admin@example.com"
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"

--- a/playbooks/archivematica-xenial/vars-singlenode-qa.yml
+++ b/playbooks/archivematica-xenial/vars-singlenode-qa.yml
@@ -41,3 +41,14 @@ mysql_users:
     host: "{{ archivematica_src_am_db_host }}"
 
 mysql_root_password: "MYSQLROOTPASSWORD"
+
+#AM configure vars
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_email: "admin@example.com"
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"


### PR DESCRIPTION
This PR uses https://github.com/artefactual-labs/ansible-archivematica-src/pull/162 to:

- create dashboard user
- create stororage-service user
- register the pipeline on storage-service

And allows to define custom user/passwords on vars files before deploying Archivematica.

Connects to https://github.com/archivematica/Issues/issues/78