### PR TITLE
Fix CentOS playbook and use Percona role

### DIFF
--- a/playbooks/archivematica-centos7/README.md
+++ b/playbooks/archivematica-centos7/README.md
@@ -7,7 +7,7 @@ Deploy](docs/digital-ocean-install-example.rst) document.
 
 ## Requirements
 
-- Vagrant 1.9.2 or newer (note that vagrant 1.9.1 has a bug when restarting network services in RHEL https://github.com/mitchellh/vagrant/pull/8148)
+- Vagrant 1.9.2 or newer (note that vagrant 1.9.1 has a bug when restarting network services in RHEL https://github.com/mitchellh/vagrant/pull/8148). Vagrant has changed its image repository URLs, so when using an old Vagrant version, see https://github.com/hashicorp/vagrant/issues/9442
 - Ansible 2.2 or newer
 
 ## How to use

--- a/playbooks/archivematica-centos7/requirements.yml
+++ b/playbooks/archivematica-centos7/requirements.yml
@@ -12,6 +12,10 @@
   version: "master"
   name: "artefactual.clamav"
 
+- src: "https://github.com/artefactual-labs/ansible-gearman.git"
+  version: "dev/centos-support"
+  name: "artefactual.gearman"
+
 - src: "https://github.com/artefactual-labs/ansible-archivematica-src"
   version: "stable/1.7.x"
   name: "artefactual.archivematica-src"

--- a/playbooks/archivematica-centos7/requirements.yml
+++ b/playbooks/archivematica-centos7/requirements.yml
@@ -4,6 +4,10 @@
   version: "2.x"
   name: "elastic.elasticsearch"
 
+- src: "https://github.com/artefactual-labs/ansible-percona"
+  version: "master"
+  name: "artefactual.percona"
+
 - src: "https://github.com/artefactual-labs/ansible-nginx"
   version: "master"
   name: "artefactual.nginx"

--- a/playbooks/archivematica-centos7/requirements.yml
+++ b/playbooks/archivematica-centos7/requirements.yml
@@ -17,7 +17,7 @@
   name: "artefactual.clamav"
 
 - src: "https://github.com/artefactual-labs/ansible-gearman.git"
-  version: "dev/centos-support"
+  version: "master"
   name: "artefactual.gearman"
 
 - src: "https://github.com/artefactual-labs/ansible-archivematica-src"

--- a/playbooks/archivematica-centos7/requirements.yml
+++ b/playbooks/archivematica-centos7/requirements.yml
@@ -4,9 +4,9 @@
   version: "2.x"
   name: "elastic.elasticsearch"
 
-- src: "https://github.com/jdauphant/ansible-role-nginx"
+- src: "https://github.com/artefactual-labs/ansible-nginx"
   version: "master"
-  name: "jdauphant.nginx"
+  name: "artefactual.nginx"
 
 - src: "https://github.com/artefactual-labs/ansible-clamav"
   version: "master"

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -20,27 +20,26 @@
         state: "latest"
       become: "yes"
 
-    - name: "Install mariadb-server, gearman"
+    - name: "Install mariadb-server"
       yum:
         name: "{{ item }}"
         state: "latest"
       with_items:
         - "mariadb-server"
-        - "gearmand"
       become: "yes"
 
-    - name: "Enable and start mariadb, gearman servers"   
+    - name: "Enable and start mariadb"
       service:
         name: "{{ item }}"
         state: "started"
         enabled: "yes"
       with_items:
         - "mariadb"
-        - "gearmand"
       become: "yes"
 
   roles:
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
+    - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
     - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
     - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -40,7 +40,7 @@
   roles:
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
     - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
-    - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
+    - { role: "artefactual.nginx", tags: ["nginx"], become: "yes" }
     - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 
   tasks:

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -10,6 +10,16 @@
       tags:
         - "always"
 
+
+    - name: "Install SELinux related python packages"
+      become: "yes"
+      yum:
+         name: "{{ item }}"
+         state: "present"
+      with_items:
+        - libsemanage-python
+        - policycoreutils-python
+
     - name: "Set SELinux to Permissive"
       command: "setenforce Permissive"      
       become: "yes"

--- a/playbooks/archivematica-centos7/singlenode-indexless.yml
+++ b/playbooks/archivematica-centos7/singlenode-indexless.yml
@@ -24,30 +24,8 @@
       command: "setenforce Permissive"      
       become: "yes"
 
-    - name: "Enable epel repository"
-      yum:
-        name: "epel-release"
-        state: "latest"
-      become: "yes"
-
-    - name: "Install mariadb-server"
-      yum:
-        name: "{{ item }}"
-        state: "latest"
-      with_items:
-        - "mariadb-server"
-      become: "yes"
-
-    - name: "Enable and start mariadb"
-      service:
-        name: "{{ item }}"
-        state: "started"
-        enabled: "yes"
-      with_items:
-        - "mariadb"
-      become: "yes"
-
   roles:
+    - { role: "artefactual.percona", tags: ["percona"], become: "yes" }
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
     - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
     - { role: "artefactual.nginx", tags: ["nginx"], become: "yes" }

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -7,6 +7,15 @@
       tags:
         - "always"
 
+    - name: "Install SELinux related python packages"
+      become: "yes"
+      yum:
+         name: "{{ item }}"
+         state: "present"
+      with_items:
+        - libsemanage-python
+        - policycoreutils-python
+
     - name: "SELinux: Allow nginx connections to Gunicorn"
       become: "yes"
       seboolean:

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -87,7 +87,7 @@
       }
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
     - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
-    - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
+    - { role: "artefactual.nginx", tags: ["nginx"], become: "yes" }
     - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 
   tasks:

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -46,23 +46,21 @@
          state: "latest"
       become: "yes"
 
-    - name: "Install mariadb-server, gearman"
+    - name: "Install mariadb-server"
       yum:
         name: "{{ item }}"
         state: "latest"
       with_items:
         - "mariadb-server"
-        - "gearmand"
       become: "yes"
 
-    - name: "Enable and start mariadb, gearman servers"   
+    - name: "Enable and start mariadb"
       service:
         name: "{{ item }}"
         state: "started"
         enabled: "yes"
       with_items:
         - "mariadb"
-        - "gearmand"
       become: "yes"
 
   roles:
@@ -88,6 +86,7 @@
         when: "archivematica_src_search_enabled|bool",
       }
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
+    - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
     - { role: "jdauphant.nginx", tags: ["nginx"], become: "yes" }
     - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -49,29 +49,6 @@
         state: "present"
       when: ansible_selinux.status == "enabled"
 
-    - name: "Enable EPEL repository"
-      yum:
-         name: "epel-release"
-         state: "latest"
-      become: "yes"
-
-    - name: "Install mariadb-server"
-      yum:
-        name: "{{ item }}"
-        state: "latest"
-      with_items:
-        - "mariadb-server"
-      become: "yes"
-
-    - name: "Enable and start mariadb"
-      service:
-        name: "{{ item }}"
-        state: "started"
-        enabled: "yes"
-      with_items:
-        - "mariadb"
-      become: "yes"
-
   roles:
     - { role: "elastic.elasticsearch", 
         tags: ["elasticsearch"], 
@@ -94,6 +71,7 @@
           },
         when: "archivematica_src_search_enabled|bool",
       }
+    - { role: "artefactual.percona", tags: ["percona"], become: "yes" }
     - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
     - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
     - { role: "artefactual.nginx", tags: ["nginx"], become: "yes" }

--- a/playbooks/archivematica-centos7/vars-singlenode.yml
+++ b/playbooks/archivematica-centos7/vars-singlenode.yml
@@ -29,7 +29,19 @@ es_allow_downgrades: false
 es_enable_xpack: false
 es_xpack_features: []
 
-#AM configure vars
+# Percona variables
+mysql_databases:
+ - name: "{{ archivematica_src_am_db_name }}"
+   collation: "utf8_general_ci"
+   encoding: "utf8"
+mysql_users:
+ - name: "{{ archivematica_src_am_db_user }}"
+   pass: "{{ archivematica_src_am_db_password }}"
+   priv: "{{ archivematica_src_am_db_name }}.*:ALL,GRANT"
+   host: "{{ archivematica_src_am_db_host }}"
+mysql_root_password: "ChangeMe!"
+
+# AM configure vars
 
 archivematica_src_configure_dashboard: "yes"
 archivematica_src_configure_ss: "yes"


### PR DESCRIPTION
These changes connect to issues #83 and #82 and add the following changes:

*The artefactual ansible-gearman role is used.
*The artefactual ansible-percona role is used
* The artefactual ansible-nginx role is used
* `libsemanage-python`, `policycoreutils-python` are installed (SELinux dependencies)

Using these roles makes this playbook practically identical to Ubuntu playbooks, except for the pre-task that configures SELinux when it is active.