### PR TITLE
Jenkins updates for am18

### DIFF
--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -6,7 +6,7 @@ node {
       env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 18.04"}', returnStdout: true).trim()
       env.DESTROY_VM = sh(script: 'echo ${DESTROY_VM:-"true"}', returnStdout: true).trim()

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -47,12 +47,12 @@ node {
         vagrant up --no-provision
         if $VAGRANT_PROVISION; then
           vagrant provision
+          vagrant ssh -c "sudo adduser ubuntu archivematica"
         fi
         vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
                                  >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
                                  >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )
 
-        vagrant ssh -c "sudo adduser ubuntu archivematica"
       '''
 
       env.SERVER = sh(script: "cat .host", returnStdout: true).trim()

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -7,6 +7,7 @@ node {
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
+      env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
@@ -90,7 +91,7 @@ node {
             --tags=$i \
             --no-skipped \
             -D am_version=${AM_VERSION} \
-            -D driver_name=Firefox \
+            -D driver_name=${WEBDRIVER} \
             -D am_username=admin \
             -D am_password=archivematica \
             -D am_url=http://${SERVER}/ \

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -5,6 +5,7 @@ node {
       env.AM_BRANCH = sh(script: 'echo ${AM_BRANCH:-"stable/1.7.x"}', returnStdout: true).trim()
       env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
+      env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
@@ -20,7 +21,7 @@ node {
         url: 'https://github.com/artefactual/archivematica-storage-service'
 
       checkout([$class: 'GitSCM',
-        branches: [[name: 'dev/jenkins-am18']],
+        branches: [[name: env.DEPLOYPUB_BRANCH]],
         doGenerateSubmoduleConfigurations: false,
         extensions:
           [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'deploy-pub']],

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -105,6 +105,11 @@ node {
             -D server_user=${USER} \
             -D transfer_source_path=${USER}/archivematica-sampledata/TestTransfers/acceptance-tests \
             -D ssh_identity_file=${KEY} \
+            -D pid_web_service_endpoint=${PID_WEB_SERVICE_ENDPOINT} \
+            -D pid_web_service_key=${PID_WEB_SERVICE_KEY} \
+            -D handle_resolver_url=${HANDLE_RESOLVER_URL} \
+            -D base_resolve_url=${BASE_RESOLVE_URL} \
+            -D pid_xml_namespace=${PID_XML_NAMESPACE} \
             --junit --junit-directory=results/ -v \
             -f=json -o=results/output-$i.json \
             --no-skipped || true

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -43,7 +43,7 @@ node {
                                 archivematica_src_configure_am_api_key="HERE_GOES_THE_AM_API_KEY" \
                                 archivematica_src_configure_ss_api_key="HERE_GOES_THE_SS_API_KEY" \
                                 archivematica_src_reset_am_all=True \
-                                archivematica_src_reset_ss_all=True"
+                                archivematica_src_reset_ss_db=True"
         vagrant up --no-provision
         if $VAGRANT_PROVISION; then
           vagrant provision

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -8,6 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 18.04"}', returnStdout: true).trim()
       env.DESTROY_VM = sh(script: 'echo ${DESTROY_VM:-"true"}', returnStdout: true).trim()
@@ -41,7 +42,9 @@ node {
                                 archivematica_src_reset_am_all=True \
                                 archivematica_src_reset_ss_all=True"
         vagrant up --no-provision
-        vagrant provision
+        if $VAGRANT_PROVISION; then
+          vagrant provision
+        fi
         vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
                                  >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
                                  >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -39,7 +39,9 @@ node {
         source ~/.secrets/openrc.sh
         ansible-galaxy install -f -p roles -r requirements.yml
         export ANSIBLE_ARGS="-e archivematica_src_am_version=${AM_BRANCH} \
-                                archivematica_src_ss_version=${SS_BRANCH}
+                                archivematica_src_ss_version=${SS_BRANCH} \
+                                archivematica_src_configure_am_api_key="HERE_GOES_THE_AM_API_KEY" \
+                                archivematica_src_configure_ss_api_key="HERE_GOES_THE_SS_API_KEY" \
                                 archivematica_src_reset_am_all=True \
                                 archivematica_src_reset_ss_all=True"
         vagrant up --no-provision
@@ -97,6 +99,7 @@ node {
             -D am_url=http://${SERVER}/ \
             -D ss_username=admin \
             -D ss_password=archivematica \
+            -D ss_api_key="HERE_GOES_THE_SS_API_KEY" \
             -D ss_url=http://${SERVER}:8000/ \
             -D home=${USER} \
             -D server_user=${USER} \

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -8,7 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events aip-encrypt aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 18.04"}', returnStdout: true).trim()
@@ -92,6 +92,7 @@ node {
           case "$i" in
             premis-events) TIMEOUT=45m;;
             ipc) TIMEOUT=45m;;
+            aip-encrypt) TIMEOUT=30m;;
             *) TIMEOUT=15m;;
           esac
           timeout $TIMEOUT env/bin/behave \

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -3,6 +3,7 @@ node {
     stage('Get code') {
       // If environment variables are defined, honour them
       env.AM_BRANCH = sh(script: 'echo ${AM_BRANCH:-"stable/1.7.x"}', returnStdout: true).trim()
+      env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc"}', returnStdout: true).trim()
@@ -19,7 +20,7 @@ node {
         url: 'https://github.com/artefactual/archivematica-storage-service'
 
       checkout([$class: 'GitSCM',
-        branches: [[name: 'dev/add-jenkins-bionic']],
+        branches: [[name: 'dev/jenkins-am18']],
         doGenerateSubmoduleConfigurations: false,
         extensions:
           [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'deploy-pub']],
@@ -84,7 +85,7 @@ node {
           timeout 30m env/bin/behave \
             --tags=$i \
             --no-skipped \
-            -D am_version=1.7 \
+            -D am_version=${AM_VERSION} \
             -D driver_name=Firefox \
             -D am_username=admin \
             -D am_password=archivematica \

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -111,7 +111,7 @@ node {
     }
 
     stage('Archive results') {
-      junit allowEmptyResults: true, keepLongStdio: true, testResults: 'results/*.xml'
+      junit allowEmptyResults: false, keepLongStdio: true, testResults: 'results/*.xml'
       cucumber 'results/cucumber-*.json'
     }
 

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -90,9 +90,9 @@ node {
         echo "Running $ACCEPTANCE_TAGS"
         for i in $ACCEPTANCE_TAGS; do
           case "$i" in
-            premis-events) TIMEOUT=45m;;
-            ipc) TIMEOUT=45m;;
-            aip-encrypt) TIMEOUT=30m;;
+            premis-events) TIMEOUT=60m;;
+            ipc) TIMEOUT=60m;;
+            aip-encrypt) TIMEOUT=45m;;
             *) TIMEOUT=15m;;
           esac
           timeout $TIMEOUT env/bin/behave \

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -8,7 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events aip-encrypt aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest icc tpc picc aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 18.04"}', returnStdout: true).trim()

--- a/playbooks/archivematica-bionic/.Jenkinsfile
+++ b/playbooks/archivematica-bionic/.Jenkinsfile
@@ -89,7 +89,12 @@ node {
       sh '''
         echo "Running $ACCEPTANCE_TAGS"
         for i in $ACCEPTANCE_TAGS; do
-          timeout 30m env/bin/behave \
+          case "$i" in
+            premis-events) TIMEOUT=45m;;
+            ipc) TIMEOUT=45m;;
+            *) TIMEOUT=15m;;
+          esac
+          timeout $TIMEOUT env/bin/behave \
             --tags=$i \
             --no-skipped \
             -D am_version=${AM_VERSION} \

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -5,6 +5,7 @@ node {
       env.AM_BRANCH = sh(script: 'echo ${AM_BRANCH:-"stable/1.7.x"}', returnStdout: true).trim()
       env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
+      env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
@@ -20,7 +21,7 @@ node {
         url: 'https://github.com/artefactual/archivematica-storage-service'
 
       checkout([$class: 'GitSCM',
-        branches: [[name: 'dev/jenkins-am18']],
+        branches: [[name: env.DEPLOYPUB_BRANCH]],
         doGenerateSubmoduleConfigurations: false,
         extensions:
           [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'deploy-pub']],

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -7,6 +7,7 @@ node {
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
+      env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
@@ -92,7 +93,7 @@ node {
             --tags=$i \
             --no-skipped \
             -D am_version=${AM_VERSION} \
-            -D driver_name=Firefox \
+            -D driver_name=${WEBDRIVER} \
             -D am_username=admin \
             -D am_password=archivematica \
             -D am_url=http://${SERVER}/ \

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -107,6 +107,11 @@ node {
             -D server_user=${USER} \
             -D transfer_source_path=${USER}/archivematica-sampledata/TestTransfers/acceptance-tests \
             -D ssh_identity_file=${KEY} \
+            -D pid_web_service_endpoint=${PID_WEB_SERVICE_ENDPOINT} \
+            -D pid_web_service_key=${PID_WEB_SERVICE_KEY} \
+            -D handle_resolver_url=${HANDLE_RESOLVER} \
+            -D base_resolve_url=${BASE_RESOLVER_URL} \
+            -D pid_xml_namespace=${PID_XML_NAMESPACE} \
             --junit --junit-directory=results/ -v \
             -f=json -o=results/output-$i.json \
             --no-skipped || true

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -8,6 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Centos 7"}', returnStdout: true).trim()
       env.DESTROY_VM = sh(script: 'echo ${DESTROY_VM:-"true"}', returnStdout: true).trim()
@@ -41,7 +42,9 @@ node {
                                 archivematica_src_reset_am_all=True \
                                 archivematica_src_reset_ss_all=True"
         vagrant up --no-provision
-        vagrant provision
+        if $VAGRANT_PROVISION; then
+          vagrant provision
+        fi
         vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
                                  >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
                                  >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -113,7 +113,7 @@ node {
     }
 
     stage('Archive results') {
-      junit allowEmptyResults: true, keepLongStdio: true, testResults: 'results/*.xml'
+      junit allowEmptyResults: false, keepLongStdio: true, testResults: 'results/*.xml'
       cucumber 'results/cucumber-*.json'
     }
 

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -43,7 +43,7 @@ node {
                                 archivematica_src_configure_am_api_key="HERE_GOES_THE_AM_API_KEY" \
                                 archivematica_src_configure_ss_api_key="HERE_GOES_THE_SS_API_KEY" \
                                 archivematica_src_reset_am_all=True \
-                                archivematica_src_reset_ss_all=True"
+                                archivematica_src_reset_ss_db=True"
         vagrant up --no-provision
         if $VAGRANT_PROVISION; then
           vagrant provision

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -8,7 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events aip-encrypt aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest icc tpc picc aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Centos 7"}', returnStdout: true).trim()

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -92,9 +92,9 @@ node {
         echo "Running $ACCEPTANCE_TAGS"
         for i in $ACCEPTANCE_TAGS; do
           case "$i" in
-            premis-events) TIMEOUT=45m;;
-            ipc) TIMEOUT=45m;;
-            aip-encrypt) TIMEOUT=30m;;
+            premis-events) TIMEOUT=60m;;
+            ipc) TIMEOUT=60m;;
+            aip-encrypt) TIMEOUT=45m;;
             *) TIMEOUT=15m;;
           esac
           timeout $TIMEOUT env/bin/behave \

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -39,7 +39,9 @@ node {
         source ~/.secrets/openrc.sh
         ansible-galaxy install -f -p roles -r requirements.yml
         export ANSIBLE_ARGS="-e archivematica_src_am_version=${AM_BRANCH} \
-                                archivematica_src_ss_version=${SS_BRANCH}
+                                archivematica_src_ss_version=${SS_BRANCH} \
+                                archivematica_src_configure_am_api_key="HERE_GOES_THE_AM_API_KEY" \
+                                archivematica_src_configure_ss_api_key="HERE_GOES_THE_SS_API_KEY" \
                                 archivematica_src_reset_am_all=True \
                                 archivematica_src_reset_ss_all=True"
         vagrant up --no-provision
@@ -99,6 +101,7 @@ node {
             -D am_url=http://${SERVER}/ \
             -D ss_username=admin \
             -D ss_password=archivematica \
+            -D ss_api_key="HERE_GOES_THE_SS_API_KEY" \
             -D ss_url=http://${SERVER}:8000/ \
             -D home=${USER} \
             -D server_user=${USER} \

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -47,14 +47,14 @@ node {
         vagrant up --no-provision
         if $VAGRANT_PROVISION; then
           vagrant provision
+          vagrant ssh -c "sudo chmod 755 /home/centos"
+          vagrant ssh -c "sudo usermod -aG archivematica centos"
+          vagrant ssh -c "sudo service firewalld stop"
         fi
         vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
                                  >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
                                  >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )
 
-        vagrant ssh -c "sudo chmod 755 /home/centos"
-        vagrant ssh -c "sudo usermod -aG archivematica centos"
-        vagrant ssh -c "sudo service firewalld stop"
       '''
 
       env.SERVER = sh(script: "cat .host", returnStdout: true).trim()

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -8,7 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events aip-encrypt aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Centos 7"}', returnStdout: true).trim()
@@ -94,6 +94,7 @@ node {
           case "$i" in
             premis-events) TIMEOUT=45m;;
             ipc) TIMEOUT=45m;;
+            aip-encrypt) TIMEOUT=30m;;
             *) TIMEOUT=15m;;
           esac
           timeout $TIMEOUT env/bin/behave \

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -1,0 +1,132 @@
+node {
+  timestamps {
+    stage('Get code') {
+      // If environment variables are defined, honour them
+      env.AM_BRANCH = sh(script: 'echo ${AM_BRANCH:-"stable/1.7.x"}', returnStdout: true).trim()
+      env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
+      env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
+      env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
+      env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Centos 7"}', returnStdout: true).trim()
+      env.DESTROY_VM = sh(script: 'echo ${DESTROY_VM:-"true"}', returnStdout: true).trim()
+      // Set build name
+      currentBuild.displayName = "#${BUILD_NUMBER} AM:${AM_BRANCH} SS:${SS_BRANCH}"
+      currentBuild.description = "OS: Centos 7 <br>Tests: ${ACCEPTANCE_TAGS}"
+
+      git branch: env.AM_BRANCH, poll: false,
+        url: 'https://github.com/artefactual/archivematica'
+      git branch: env.SS_BRANCH, poll: false,
+        url: 'https://github.com/artefactual/archivematica-storage-service'
+
+      checkout([$class: 'GitSCM',
+        branches: [[name: 'dev/jenkins-am18']],
+        doGenerateSubmoduleConfigurations: false,
+        extensions:
+          [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'deploy-pub']],
+          submoduleCfg: [],
+          userRemoteConfigs: [[url: 'https://github.com/artefactual/deploy-pub']]])
+
+    }
+
+    stage ('Create vm') {
+      sh '''
+        echo Building Archivematica $AM_BRANCH and Storage Service $SS_BRANCH
+        cd deploy-pub/playbooks/archivematica-centos7
+        source ~/.secrets/openrc.sh
+        ansible-galaxy install -f -p roles -r requirements.yml
+        export ANSIBLE_ARGS="-e archivematica_src_am_version=${AM_BRANCH} \
+                                archivematica_src_ss_version=${SS_BRANCH}
+                                archivematica_src_reset_am_all=True \
+                                archivematica_src_reset_ss_all=True"
+        vagrant up --no-provision
+        vagrant provision
+        vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
+                                 >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
+                                 >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )
+
+        vagrant ssh -c "sudo chmod 755 /home/centos"
+        vagrant ssh -c "sudo usermod -aG archivematica centos"
+        vagrant ssh -c "sudo service firewalld stop"
+      '''
+
+      env.SERVER = sh(script: "cat .host", returnStdout: true).trim()
+      env.USER = sh(script: "cat .user", returnStdout: true).trim()
+      env.KEY = sh(script: "cat .key", returnStdout: true).trim()
+    }
+
+    stage('Configure acceptance tests') {
+      git branch: 'master', url: 'https://github.com/artefactual-labs/archivematica-acceptance-tests'
+        properties([disableConcurrentBuilds(),
+        gitLabConnection(''),
+        [$class: 'RebuildSettings',
+        autoRebuild: false,
+        rebuildDisabled: false],
+        pipelineTriggers([pollSCM('*/5 * * * *')])])
+
+
+      sh '''
+        virtualenv -p python3 env
+        env/bin/pip install -r requirements.txt
+        env/bin/pip install behave2cucumber
+        # Launch vnc server
+        VNCPID=$(ps aux | grep Xtig[h] | grep ${DISPLAY} | awk '{print $2}')
+        if [ "x$VNCPID" == "x" ]; then
+          tightvncserver -geometry 1920x1080 ${DISPLAY}
+        fi
+
+        mkdir -p results/
+        rm -rf results/*
+      '''
+    }
+
+    stage('Run tests') {
+      sh '''
+        echo "Running $ACCEPTANCE_TAGS"
+        for i in $ACCEPTANCE_TAGS; do
+          timeout 30m env/bin/behave \
+            --tags=$i \
+            --no-skipped \
+            -D am_version=${AM_VERSION} \
+            -D driver_name=Firefox \
+            -D am_username=admin \
+            -D am_password=archivematica \
+            -D am_url=http://${SERVER}/ \
+            -D ss_username=admin \
+            -D ss_password=archivematica \
+            -D ss_url=http://${SERVER}:8000/ \
+            -D home=${USER} \
+            -D server_user=${USER} \
+            -D transfer_source_path=${USER}/archivematica-sampledata/TestTransfers/acceptance-tests \
+            -D ssh_identity_file=${KEY} \
+            --junit --junit-directory=results/ -v \
+            -f=json -o=results/output-$i.json \
+            --no-skipped || true
+
+          env/bin/python -m behave2cucumber  -i results/output-$i.json -o results/cucumber-$i.json || true
+        done
+      '''
+    }
+
+    stage('Archive results') {
+      junit allowEmptyResults: true, keepLongStdio: true, testResults: 'results/*.xml'
+      cucumber 'results/cucumber-*.json'
+    }
+
+    stage('Cleanup') {
+      sh '''
+        # Kill vnc server
+        VNCPID=$(ps aux | grep Xtig[h] | grep ${DISPLAY} | awk '{print $2}')
+        if [ "x$VNCPID" != "x" ]; then
+          kill $VNCPID
+        fi
+        # Remove vm
+        if $DESTROY_VM; then
+          cd deploy-pub/playbooks/archivematica-centos7/
+          source ~/.secrets/openrc.sh
+          vagrant destroy
+        fi
+      '''
+    }
+  }
+}

--- a/playbooks/archivematica-centos7/.Jenkinsfile
+++ b/playbooks/archivematica-centos7/.Jenkinsfile
@@ -91,7 +91,12 @@ node {
       sh '''
         echo "Running $ACCEPTANCE_TAGS"
         for i in $ACCEPTANCE_TAGS; do
-          timeout 30m env/bin/behave \
+          case "$i" in
+            premis-events) TIMEOUT=45m;;
+            ipc) TIMEOUT=45m;;
+            *) TIMEOUT=15m;;
+          esac
+          timeout $TIMEOUT env/bin/behave \
             --tags=$i \
             --no-skipped \
             -D am_version=${AM_VERSION} \

--- a/playbooks/archivematica-centos7/Vagrantfile.openstack
+++ b/playbooks/archivematica-centos7/Vagrantfile.openstack
@@ -1,0 +1,47 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+#
+# This is quite the minimal configuration necessary
+# to start an OpenStack instance using Vagrant.
+#
+# This example assumes a floating IP is needed to
+# reach the machine, although you might remove the
+# floating_ip_pool parameter if you are able to join
+# the instance using its private IP address (e.g.
+# through a VPN).
+#
+Vagrant.configure('2') do |config|
+
+  config.ssh.username = "centos"
+
+  config.vm.provider :openstack do |os, ov|
+    os.openstack_auth_url               = ENV['OS_AUTH_URL']
+    os.tenant_name                      = ENV['OS_TENANT_NAME']
+    os.username                         = ENV['OS_USERNAME']
+    os.password                         = ENV['OS_PASSWORD']
+    os.region                           = ENV['OS_REGION_NAME']
+    os.flavor                           = ENV['OS_FLAVOR']
+    ov.vm.allowed_synced_folder_types = :rsync
+    ov.nfs.functional = false
+  end
+
+  config.vm.define 'am-local-centos7' do |s|
+    s.vm.provider :openstack do |os, override|
+      os.image = ENV['OS_IMAGE']
+      os.server_name = 'archivematica-centos7'
+    end
+  end
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "./singlenode.yml"
+    ansible.host_key_checking = false
+    ansible.extra_vars = {
+      "archivematica_src_dir" => "/opt/archivematica",
+      "archivematica_src_environment_type" => "development",
+    }
+    # Accept multiple arguments, separated by colons
+    ansible.raw_arguments = ENV['ANSIBLE_ARGS'].to_s.split(':')
+  end
+
+end

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -9,7 +9,7 @@ node {
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
 
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events aip-encrypt aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 16.04"}', returnStdout: true).trim()
@@ -94,6 +94,7 @@ node {
           case "$i" in
             premis-events) TIMEOUT=45m;;
             ipc) TIMEOUT=45m;;
+            aip-encrypt) TIMEOUT=30m;;
             *) TIMEOUT=15m;;
           esac
           timeout $TIMEOUT env/bin/behave \

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -5,6 +5,7 @@ node {
       env.AM_BRANCH = sh(script: 'echo ${AM_BRANCH:-"stable/1.7.x"}', returnStdout: true).trim()
       env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
+      env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
@@ -20,7 +21,7 @@ node {
         url: 'https://github.com/artefactual/archivematica-storage-service'
 
       checkout([$class: 'GitSCM',
-        branches: [[name: 'dev/jenkins-am18']],
+        branches: [[name: env.DEPLOYPUB_BRANCH]],
         doGenerateSubmoduleConfigurations: false,
         extensions:
           [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'deploy-pub']],

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -112,7 +112,7 @@ node {
     }
 
     stage('Archive results') {
-      junit allowEmptyResults: true, keepLongStdio: true, testResults: 'results/*.xml'
+      junit allowEmptyResults: false, keepLongStdio: true, testResults: 'results/*.xml'
       cucumber 'results/cucumber-*.json'
     }
 

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -40,7 +40,9 @@ node {
         source ~/.secrets/openrc.sh
         ansible-galaxy install -f -p roles -r requirements.yml
         export ANSIBLE_ARGS="-e archivematica_src_am_version=${AM_BRANCH} \
-                                archivematica_src_ss_version=${SS_BRANCH}
+                                archivematica_src_ss_version=${SS_BRANCH} \
+                                archivematica_src_configure_am_api_key="HERE_GOES_THE_AM_API_KEY" \
+                                archivematica_src_configure_ss_api_key="HERE_GOES_THE_SS_API_KEY" \
                                 archivematica_src_reset_am_all=True \
                                 archivematica_src_reset_ss_all=True"
         vagrant up --no-provision
@@ -99,6 +101,7 @@ node {
             -D am_url=http://${SERVER}/ \
             -D ss_username=admin \
             -D ss_password=archivematica \
+            -D ss_api_key="HERE_GOES_THE_SS_API_KEY" \
             -D ss_url=http://${SERVER}:8000/ \
             -D home=${USER} \
             -D server_user=${USER} \

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -92,9 +92,9 @@ node {
         echo "Running $ACCEPTANCE_TAGS"
         for i in $ACCEPTANCE_TAGS; do
           case "$i" in
-            premis-events) TIMEOUT=45m;;
-            ipc) TIMEOUT=45m;;
-            aip-encrypt) TIMEOUT=30m;;
+            premis-events) TIMEOUT=60m;;
+            ipc) TIMEOUT=60m;;
+            aip-encrypt) TIMEOUT=45m;;
             *) TIMEOUT=15m;;
           esac
           timeout $TIMEOUT env/bin/behave \

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -1,0 +1,130 @@
+node {
+  timestamps {
+    stage('Get code') {
+      // If environment variables are defined, honour them
+      env.AM_BRANCH = sh(script: 'echo ${AM_BRANCH:-"stable/1.7.x"}', returnStdout: true).trim()
+      env.AM_VERSION = sh(script: 'echo ${AM_VERSION:-"1.7"}', returnStdout: true).trim()
+      env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
+      env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
+      env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 16.04"}', returnStdout: true).trim()
+      env.DESTROY_VM = sh(script: 'echo ${DESTROY_VM:-"true"}', returnStdout: true).trim()
+      // Set build name
+      currentBuild.displayName = "#${BUILD_NUMBER} AM:${AM_BRANCH} SS:${SS_BRANCH}"
+      currentBuild.description = "OS: Ubuntu 16.04 <br>Tests: ${ACCEPTANCE_TAGS}"
+
+      git branch: env.AM_BRANCH, poll: false,
+        url: 'https://github.com/artefactual/archivematica'
+      git branch: env.SS_BRANCH, poll: false,
+        url: 'https://github.com/artefactual/archivematica-storage-service'
+
+      checkout([$class: 'GitSCM',
+        branches: [[name: 'dev/jenkins-am18']],
+        doGenerateSubmoduleConfigurations: false,
+        extensions:
+          [[$class: 'RelativeTargetDirectory', relativeTargetDir: 'deploy-pub']],
+          submoduleCfg: [],
+          userRemoteConfigs: [[url: 'https://github.com/artefactual/deploy-pub']]])
+
+    }
+
+    stage ('Create vm') {
+      sh '''
+        echo Building Archivematica $AM_BRANCH and Storage Service $SS_BRANCH
+        cd deploy-pub/playbooks/archivematica-xenial
+        source ~/.secrets/openrc.sh
+        ansible-galaxy install -f -p roles -r requirements.yml
+        export ANSIBLE_ARGS="-e archivematica_src_am_version=${AM_BRANCH} \
+                                archivematica_src_ss_version=${SS_BRANCH}
+                                archivematica_src_reset_am_all=True \
+                                archivematica_src_reset_ss_all=True"
+        vagrant up --no-provision
+        vagrant provision
+        vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
+                                 >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
+                                 >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )
+
+        vagrant ssh -c "sudo adduser ubuntu archivematica"
+      '''
+
+      env.SERVER = sh(script: "cat .host", returnStdout: true).trim()
+      env.USER = sh(script: "cat .user", returnStdout: true).trim()
+      env.KEY = sh(script: "cat .key", returnStdout: true).trim()
+    }
+
+    stage('Configure acceptance tests') {
+      git branch: 'master', url: 'https://github.com/artefactual-labs/archivematica-acceptance-tests'
+        properties([disableConcurrentBuilds(),
+        gitLabConnection(''),
+        [$class: 'RebuildSettings',
+        autoRebuild: false,
+        rebuildDisabled: false],
+        pipelineTriggers([pollSCM('*/5 * * * *')])])
+
+
+      sh '''
+        virtualenv -p python3 env
+        env/bin/pip install -r requirements.txt
+        env/bin/pip install behave2cucumber
+        # Launch vnc server
+        VNCPID=$(ps aux | grep Xtig[h] | grep ${DISPLAY} | awk '{print $2}')
+        if [ "x$VNCPID" == "x" ]; then
+          tightvncserver -geometry 1920x1080 ${DISPLAY}
+        fi
+
+        mkdir -p results/
+        rm -rf results/*
+      '''
+    }
+
+    stage('Run tests') {
+      sh '''
+        echo "Running $ACCEPTANCE_TAGS"
+        for i in $ACCEPTANCE_TAGS; do
+          timeout 30m env/bin/behave \
+            --tags=$i \
+            --no-skipped \
+            -D am_version=${AM_VERSION} \
+            -D driver_name=Firefox \
+            -D am_username=admin \
+            -D am_password=archivematica \
+            -D am_url=http://${SERVER}/ \
+            -D ss_username=admin \
+            -D ss_password=archivematica \
+            -D ss_url=http://${SERVER}:8000/ \
+            -D home=${USER} \
+            -D server_user=${USER} \
+            -D transfer_source_path=${USER}/archivematica-sampledata/TestTransfers/acceptance-tests \
+            -D ssh_identity_file=${KEY} \
+            --junit --junit-directory=results/ -v \
+            -f=json -o=results/output-$i.json \
+            --no-skipped || true
+
+          env/bin/python -m behave2cucumber  -i results/output-$i.json -o results/cucumber-$i.json || true
+        done
+      '''
+    }
+
+    stage('Archive results') {
+      junit allowEmptyResults: true, keepLongStdio: true, testResults: 'results/*.xml'
+      cucumber 'results/cucumber-*.json'
+    }
+
+    stage('Cleanup') {
+      sh '''
+        # Kill vnc server
+        VNCPID=$(ps aux | grep Xtig[h] | grep ${DISPLAY} | awk '{print $2}')
+        if [ "x$VNCPID" != "x" ]; then
+          kill $VNCPID
+        fi
+        # Remove vm
+        if $DESTROY_VM; then
+          cd deploy-pub/playbooks/archivematica-xenial/
+          source ~/.secrets/openrc.sh
+          vagrant destroy
+        fi
+      '''
+    }
+  }
+}

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -8,6 +8,7 @@ node {
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 16.04"}', returnStdout: true).trim()
       env.DESTROY_VM = sh(script: 'echo ${DESTROY_VM:-"true"}', returnStdout: true).trim()
@@ -41,7 +42,10 @@ node {
                                 archivematica_src_reset_am_all=True \
                                 archivematica_src_reset_ss_all=True"
         vagrant up --no-provision
-        vagrant provision
+        if $VAGRANT_PROVISION; then
+          vagrant provision
+        fi
+
         vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
                                  >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
                                  >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -7,6 +7,8 @@ node {
       env.SS_BRANCH = sh(script: 'echo ${SS_BRANCH:-"stable/0.12.x"}', returnStdout: true).trim()
       env.DEPLOYPUB_BRANCH = sh(script: 'echo ${DEPLOYPUB_BRANCH:-"master"}', returnStdout: true).trim()
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
+      env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
+
       env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events pid-binding aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
@@ -91,7 +93,7 @@ node {
             --tags=$i \
             --no-skipped \
             -D am_version=${AM_VERSION} \
-            -D driver_name=Firefox \
+            -D driver_name=${WEBDRIVER} \
             -D am_username=admin \
             -D am_password=archivematica \
             -D am_url=http://${SERVER}/ \

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -107,6 +107,11 @@ node {
             -D server_user=${USER} \
             -D transfer_source_path=${USER}/archivematica-sampledata/TestTransfers/acceptance-tests \
             -D ssh_identity_file=${KEY} \
+            -D pid_web_service_endpoint=${PID_WEB_SERVICE_ENDPOINT} \
+            -D pid_web_service_key=${PID_WEB_SERVICE_KEY} \
+            -D handle_resolver_url=${HANDLE_RESOLVER_URL} \
+            -D base_resolve_url=${BASE_RESOLVE_URL} \
+            -D pid_xml_namespace=${PID_XML_NAMESPACE} \
             --junit --junit-directory=results/ -v \
             -f=json -o=results/output-$i.json \
             --no-skipped || true

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -44,7 +44,7 @@ node {
                                 archivematica_src_configure_am_api_key="HERE_GOES_THE_AM_API_KEY" \
                                 archivematica_src_configure_ss_api_key="HERE_GOES_THE_SS_API_KEY" \
                                 archivematica_src_reset_am_all=True \
-                                archivematica_src_reset_ss_all=True"
+                                archivematica_src_reset_ss_db=True"
         vagrant up --no-provision
         if $VAGRANT_PROVISION; then
           vagrant provision

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -9,7 +9,7 @@ node {
       env.DISPLAY = sh(script: 'echo ${DISPLAY:-:50}', returnStdout: true).trim()
       env.WEBDRIVER = sh(script: 'echo ${WEBDRIVER:-"Firefox"}', returnStdout: true).trim()
 
-      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest ipc icc tpc picc premis-events aip-encrypt aip-encrypt-mirror"}', returnStdout: true).trim()
+      env.ACCEPTANCE_TAGS = sh(script: 'echo ${ACCEPTANCE_TAGS:-"uuids-dirs mo-aip-reingest icc tpc picc aip-encrypt-mirror"}', returnStdout: true).trim()
       env.VAGRANT_PROVISION = sh(script: 'echo ${VAGRANT_PROVISION:-"true"}', returnStdout: true).trim()
       env.VAGRANT_VAGRANTFILE = sh(script: 'echo ${VAGRANT_VAGRANTFILE:-Vagrantfile.openstack}', returnStdout: true).trim()
       env.OS_IMAGE = sh(script: 'echo ${OS_IMAGE:-"Ubuntu 16.04"}', returnStdout: true).trim()

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -91,7 +91,12 @@ node {
       sh '''
         echo "Running $ACCEPTANCE_TAGS"
         for i in $ACCEPTANCE_TAGS; do
-          timeout 30m env/bin/behave \
+          case "$i" in
+            premis-events) TIMEOUT=45m;;
+            ipc) TIMEOUT=45m;;
+            *) TIMEOUT=15m;;
+          esac
+          timeout $TIMEOUT env/bin/behave \
             --tags=$i \
             --no-skipped \
             -D am_version=${AM_VERSION} \

--- a/playbooks/archivematica-xenial/.Jenkinsfile
+++ b/playbooks/archivematica-xenial/.Jenkinsfile
@@ -48,13 +48,13 @@ node {
         vagrant up --no-provision
         if $VAGRANT_PROVISION; then
           vagrant provision
+          vagrant ssh -c "sudo adduser ubuntu archivematica"
         fi
 
         vagrant ssh-config | tee >( grep HostName  | awk '{print $2}' > $WORKSPACE/.host) \
                                  >( grep User | awk '{print $2}' > $WORKSPACE/.user ) \
                                  >( grep IdentityFile | awk '{print $2}' > $WORKSPACE/.key )
 
-        vagrant ssh -c "sudo adduser ubuntu archivematica"
       '''
 
       env.SERVER = sh(script: "cat .host", returnStdout: true).trim()

--- a/playbooks/archivematica-xenial/Vagrantfile.openstack
+++ b/playbooks/archivematica-xenial/Vagrantfile.openstack
@@ -1,0 +1,50 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+#
+# This is quite the minimal configuration necessary
+# to start an OpenStack instance using Vagrant.
+#
+# This example assumes a floating IP is needed to
+# reach the machine, although you might remove the
+# floating_ip_pool parameter if you are able to join
+# the instance using its private IP address (e.g.
+# through a VPN).
+#
+Vagrant.configure('2') do |config|
+
+  config.ssh.username = "ubuntu"
+
+  config.vm.provider :openstack do |os, ov|
+    os.openstack_auth_url               = ENV['OS_AUTH_URL']
+    os.tenant_name                      = ENV['OS_TENANT_NAME']
+    os.username                         = ENV['OS_USERNAME']
+    os.password                         = ENV['OS_PASSWORD']
+    os.region                           = ENV['OS_REGION_NAME']
+    os.flavor                           = ENV['OS_FLAVOR']
+    ov.vm.allowed_synced_folder_types = :rsync
+    ov.nfs.functional = false
+  end
+
+  config.vm.define 'am-local' do |s|
+    s.vm.provider :openstack do |os, override|
+      os.image = ENV['OS_IMAGE']
+      os.server_name = 'archivematica-xenial'
+    end
+  end
+
+  # Ansible provisioning
+  config.vm.provision "shell", inline: "sudo apt-get install -y python"
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "./singlenode.yml"
+    ansible.host_key_checking = false
+    ansible.extra_vars = {
+      "archivematica_src_dir" => "/opt/archivematica",
+      "archivematica_src_environment_type" => "development",
+    }
+    # Accept multiple arguments, separated by colons
+    ansible.raw_arguments = ENV['ANSIBLE_ARGS'].to_s.split(':')
+  end
+
+end


### PR DESCRIPTION
This pull request adds support for Ubuntu 16.04 and Centos 7, using #93 as template for the jobs.

This also adds two new settings:
 * `AM_VERSION`: Which AM version are we testing. Default is `1.7`
 * `DEPLOYPUB_BRANCH`: Which branch to use from deploy-pub. Default is `master`. This was needed to test the pull request from the development branch, before it's merged.
 * `VAGRANT_PROVISION`: Chooses when to reprovision (reset) the VM. The default is `true`, but for quick tests it can be set to `false`, and reuse a previously provisioned vm



Connects to https://github.com/archivematica/Issues/issues/180