### PR TITLE
Align archivematica centos and ubuntu playbooks

### DIFF
--- a/playbooks/archivematica-bionic/singlenode.yml
+++ b/playbooks/archivematica-bionic/singlenode.yml
@@ -28,6 +28,11 @@
       tags:
         - "percona"
 
+    - role: "artefactual.nginx"
+      become: "yes"
+      tags:
+        - "nginx"
+
     - role: "artefactual.gearman"
       become: "yes"
       tags:

--- a/playbooks/archivematica-centos7/requirements.yml
+++ b/playbooks/archivematica-centos7/requirements.yml
@@ -1,8 +1,8 @@
 ---
 
-- src: "https://github.com/elastic/ansible-elasticsearch"
-  version: "2.x"
-  name: "elastic.elasticsearch"
+- src: "https://github.com/artefactual-labs/ansible-elasticsearch"
+  version: "master"
+  name: "artefactual.elasticsearch"
 
 - src: "https://github.com/artefactual-labs/ansible-percona"
   version: "master"

--- a/playbooks/archivematica-centos7/singlenode.yml
+++ b/playbooks/archivematica-centos7/singlenode.yml
@@ -7,79 +7,35 @@
       tags:
         - "always"
 
-    - name: "Install SELinux related python packages"
-      become: "yes"
-      yum:
-         name: "{{ item }}"
-         state: "present"
-      with_items:
-        - libsemanage-python
-        - policycoreutils-python
-
-    - name: "SELinux: Allow nginx connections to Gunicorn"
-      become: "yes"
-      seboolean:
-        name: "httpd_can_network_connect"
-        state: "yes"
-        persistent: "yes"
-      when: ansible_selinux.status == "enabled"
-
-    - name: "SELinux: Allow nginx to connect to MySQL"
-      become: "yes"
-      seboolean:
-        name: "httpd_can_network_connect_db"
-        state: "yes"
-        persistent: "yes"
-      when: ansible_selinux.status == "enabled"
-
-    - name: "SELinux: Allow nginx to change system limits"
-      become: "yes"
-      seboolean:
-        name: "httpd_setrlimit"
-        state: "yes"
-        persistent: "yes"
-      when: ansible_selinux.status == "enabled"
-
-    - name: "SELinux: Allow nginx to use ports 8000 and 8001"
-      become: "yes"
-      seport:
-        ports: "8000,8001"
-        proto: "tcp"
-        setype: "http_port_t"
-        state: "present"
-      when: ansible_selinux.status == "enabled"
-
   roles:
-    - { role: "elastic.elasticsearch", 
-        tags: ["elasticsearch"], 
-        become: "yes",
-        # instance specific settings here, general settings in host_vars
-        es_instance_name: "node1", 
-        es_data_dirs: "/opt/elasticsearch/data", 
-        es_log_dir: "/opt/elasticsearch/logs", 
-        es_work_dir: "/opt/elasticsearch/temp", 
-        es_config: {
-          node.name: "node1", 
-          cluster.name: "cluster1",
-          http.port: 9200,
-          transport.tcp.port: 9300,
-          node.data: true,
-          node.master: true,
-          bootstrap.mlockall: true,
-          discovery.zen.ping.multicast.enabled: false,
-          http.max_content_length: 1024mb 
-          },
-        when: "archivematica_src_search_enabled|bool",
-      }
-    - { role: "artefactual.percona", tags: ["percona"], become: "yes" }
-    - { role: "artefactual.clamav", tags: ["clamav"], become: "yes" }
-    - { role: "artefactual.gearman", tags: ["gearman"], become: "yes" }
-    - { role: "artefactual.nginx", tags: ["nginx"], become: "yes" }
-    - { role: "artefactual.archivematica-src", tags: ["archivematica-src"], become: "yes" }
 
-  tasks:
-    - name: "change home dir perms (to make transfer source visible)"
-      command: "chmod 755 $HOME" 
-      tags: "homeperms"
-      become: "no"
+    - role: "artefactual.elasticsearch"
+      become: "yes"
+      tags:
+        - "elasticsearch"
+      when: "archivematica_src_search_enabled|bool"
 
+    - role: "artefactual.percona"
+      become: "yes"
+      tags:
+        - "percona"
+
+    - role: "artefactual.nginx"
+      become: "yes"
+      tags:
+        - "nginx"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+      tags:
+        - "gearman"
+
+    - role: "artefactual.clamav"
+      become: "yes"
+      tags:
+        - "clamav"
+
+    - role: "artefactual.archivematica-src"
+      become: "yes"
+      tags:
+        - "archivematica-src"

--- a/playbooks/archivematica-xenial/singlenode.yml
+++ b/playbooks/archivematica-xenial/singlenode.yml
@@ -28,6 +28,11 @@
       tags:
         - "percona"
 
+    - role: "artefactual.nginx"
+      become: "yes"
+      tags:
+        - "percona"
+
     - role: "artefactual.gearman"
       become: "yes"
       tags:


### PR DESCRIPTION
After merging 
https://github.com/artefactual-labs/ansible-archivematica-src/pull/232 we can remove the tasks that were running as part of the centos playbook, and rely on archivematica role for them, so now all playbooks are more or lest the same.


Connects to https://github.com/artefactual/archivematica/issues/1171