### PR TITLE
Use atom_auto_init

### DIFF
--- a/playbooks/atom-bionic/Vagrantfile
+++ b/playbooks/atom-bionic/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "atom_user" => "vagrant",
       "atom_group" => "vagrant",
       "atom_environment_type" => "development",
-      "atom_flush_data" => "yes",
+      "atom_auto_init" => "yes",
       "es_config" => {
         "network.host" => "127.0.0.1"
       }

--- a/playbooks/atom-xenial/Vagrantfile
+++ b/playbooks/atom-xenial/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       "atom_user" => "vagrant",
       "atom_group" => "vagrant",
       "atom_environment_type" => "development",
-      "atom_flush_data" => "yes",
+      "atom_auto_init" => "yes",
       "es_config" => {
         "network.host" => "0.0.0.0"
       }


### PR DESCRIPTION
Use `atom_auto_init` in AtoM deployments, disable `atom_flush_data`. This helps prevent accidental flushing user data.

Connects to https://github.com/artefactual-labs/ansible-atom/issues/71.