### PR TITLE
Always update cache when installing archivematica

### DIFF
--- a/playbooks/archivematica-bionic/singlenode-indexless.yml
+++ b/playbooks/archivematica-bionic/singlenode-indexless.yml
@@ -14,6 +14,8 @@
       apt:
         pkg: "{{ item }}"
         state: "latest"
+        update_cache: yes
+        cache_valid_time: 0
       with_items:
         - "fish"
       become: "yes"

--- a/playbooks/archivematica-bionic/singlenode.yml
+++ b/playbooks/archivematica-bionic/singlenode.yml
@@ -11,6 +11,8 @@
       apt:
         pkg: "{{ item }}"
         state: "latest"
+        update_cache: yes
+        cache_valid_time: 0
       with_items:
         - "fish"
       become: "yes"


### PR DESCRIPTION
If you go from a brand new deployment of a server in Ubuntu, the cache
for apt may be out of date. This amounts to running `apt-get update`
which will make it so this doesn't fail, otherwise the `fish` package
won't exist.