### PR TITLE
am-jammy: Update HOME dir permissions

### DIFF
--- a/playbooks/archivematica-jammy/singlenode.yml
+++ b/playbooks/archivematica-jammy/singlenode.yml
@@ -47,3 +47,11 @@
       become: "yes"
       tags:
         - "archivematica-src"
+
+  post_tasks:
+
+    - name: "change home dir perms (to make transfer source visible)"
+      become: "no"
+      command: "chmod 755 $HOME"
+      tags:
+        - "homeperms"


### PR DESCRIPTION
Default /home dir permissions have changed in Ubuntu Jammy. 