### PR TITLE
Add AMAUATs test workflow

### DIFF
--- a/.github/workflows/archivematica-acceptance-tests.yml
+++ b/.github/workflows/archivematica-acceptance-tests.yml
@@ -1,0 +1,186 @@
+name: "Archivematica Acceptance Tests"
+on:
+  workflow_dispatch:
+    inputs:
+      am_version:
+        description: "Archivematica ref (branch, tag or SHA to checkout)"
+        default: "qa/1.x"
+        required: true
+        type: "string"
+      ss_version:
+        description: "Archivematica Storage Service ref (branch, tag or SHA to checkout)"
+        default: "qa/0.x"
+        required: true
+        type: "string"
+      amauats_version:
+        description: "Archivematica Acceptance Test ref (branch, tag or SHA to checkout)"
+        default: "qa/1.x"
+        required: true
+        type: "string"
+jobs:
+  test:
+    name: "${{ matrix.vagrant-box.label }} / ${{ matrix.feature }}"
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        vagrant-box:
+          - id: "rockylinux/9"
+            label: "rocky9"
+          - id: "ubuntu/jammy64"
+            label: "jammy"
+        feature:
+          - "aip-encryption-mirror"
+          - "aip-encryption"
+          - "checksum"
+          - "create-aip"
+          - "description-rights"
+          - "extract-package"
+          - "ingest-mkv-conformance"
+          - "ingest-policy-check"
+          - "metadata-xml"
+          - "reingest-aip"
+          - "transfer-microservices"
+          - "transfer-mkv-conformance"
+          - "transfer-policy-check"
+          - "uuids-for-directories"
+          - "virus"
+        browser:
+          - "Chrome"
+    steps:
+      - name: "Check out code"
+        uses: "actions/checkout@v4"
+      - name: "Check out AM code"
+        uses: "actions/checkout@v4"
+        with:
+          repository: "artefactual/archivematica"
+          ref: "${{ inputs.am_version }}"
+          path: "${{ github.workspace }}/AM"
+      - name: "Check out SS code"
+        uses: "actions/checkout@v4"
+        with:
+          repository: "artefactual/archivematica-storage-service"
+          ref: "${{ inputs.ss_version }}"
+          path: "${{ github.workspace }}/SS"
+      - name: "Check out AMAUATs code"
+        uses: "actions/checkout@v4"
+        with:
+          repository: "artefactual-labs/archivematica-acceptance-tests"
+          ref: "${{ inputs.amauats_version }}"
+          path: "${{ github.workspace }}/AMAUATs"
+      - name: "Install Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.9"
+      - name: "Install Vagrant"
+        run: |
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt install vagrant
+      - name: "Install VirtualBox"
+        run: |
+          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian jammy contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+          sudo apt update && sudo apt install virtualbox-7.0
+      - name: "Install the vagrant-vbguest plugin"
+        run: |
+          vagrant plugin install vagrant-vbguest
+      - name: "Update vbox networks"
+        run: |
+          sudo mkdir -p /etc/vbox/
+          echo "* 192.168.33.0/24" | sudo tee -a /etc/vbox/networks.conf
+      - name: "Start VM"
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        env:
+          VAGRANT_BOX: "${{ matrix.vagrant-box.id }}"
+        run: |
+          vagrant up
+      - name: "Resize root partition in Rocky 9"
+        if: matrix.vagrant-box.id == 'rockylinux/9'
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        run: |
+          vagrant ssh -c 'echo "- +" | sudo sfdisk --no-reread -N 5 /dev/sda'
+          vagrant reload
+          vagrant ssh -c 'sudo xfs_growfs /dev/sda5'
+      - name: "Install Archivematica"
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+        run: |
+          ansible-galaxy install -f -p roles/ -r requirements.yml
+          ansible-playbook -i 192.168.33.2, playbook.yml \
+              -u vagrant \
+              --private-key ${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key \
+              -e "archivematica_src_am_version=${{ inputs.am_version }} archivematica_src_ss_version=${{ inputs.ss_version }}" \
+              -v
+      - name: "Prepare VM for running AMAUATs"
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        run: |
+          vagrant ssh -c 'sudo usermod -a -G archivematica vagrant'
+          vagrant ssh -c 'sudo ln -s /home/vagrant /home/archivematica'
+      - name: "Set up AMAUATs"
+        working-directory: "${{ github.workspace }}/AMAUATs"
+        run: |
+          python3 -m venv .venv
+          .venv/bin/python3 -m pip install -r requirements.txt
+      - name: "Run AMAUATs"
+        id: "amauat-run"
+        working-directory: "${{ github.workspace }}/AMAUATs"
+        env:
+          HEADLESS: 1
+        run: |
+          .venv/bin/behave -i ${{ matrix.feature }}.feature \
+              -v \
+              --no-capture \
+              --no-capture-stderr \
+              --no-logcapture \
+              --no-skipped \
+              -D am_version=1.9 \
+              -D driver_name=${{ matrix.browser }} \
+              -D am_username=admin \
+              -D am_password=archivematica \
+              -D am_url=http://192.168.33.2/ \
+              -D am_api_key="this_is_the_am_api_key" \
+              -D ss_username=admin \
+              -D ss_password=archivematica \
+              -D ss_api_key="this_is_the_ss_api_key" \
+              -D ss_url=http://192.168.33.2:8000/ \
+              -D home=vagrant \
+              -D server_user=vagrant \
+              -D transfer_source_path=/home/vagrant/archivematica-sampledata/TestTransfers/acceptance-tests \
+              -D ssh_identity_file=${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key
+      - name: "Save logs on failure"
+        if: matrix.vagrant-box.id == 'ubuntu/jammy64' && (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled')
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        run: |
+          mkdir /tmp/logs
+          vagrant ssh -c 'mkdir -p /tmp/logs/journalctl'
+          vagrant ssh -c 'sudo cp -r /var/log/{archivematica,mysql,elasticsearch,gearman-job-server,clamav,nginx} /tmp/logs'
+          vagrant ssh -c 'sudo journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
+          vagrant ssh -c 'sudo chown -R vagrant /tmp/logs'
+          scp \
+              -i ${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key \
+              -o "StrictHostKeyChecking=no" \
+              -r \
+              vagrant@192.168.33.2:/tmp/logs /tmp/logs
+      - name: "Save logs on failure"
+        if: matrix.vagrant-box.id == 'rockylinux/9' && (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled')
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        run: |
+          mkdir /tmp/logs
+          vagrant ssh -c 'mkdir -p /tmp/logs/journalctl'
+          vagrant ssh -c 'sudo cp -r /var/log/{archivematica,mysqld.log,elasticsearch,nginx} /tmp/logs'
+          vagrant ssh -c 'sudo journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
+          vagrant ssh -c 'sudo journalctl -u clamd@scan --no-pager > /tmp/logs/journalctl/clamd'
+          vagrant ssh -c 'sudo chown -R vagrant /tmp/logs'
+          scp \
+              -i ${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key \
+              -o "StrictHostKeyChecking=no" \
+              -r \
+              vagrant@192.168.33.2:/tmp/logs /tmp/logs
+      - name: "Upload logs on failure"
+        if: "${{ (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled') }}"
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "logs-${{ matrix.vagrant-box.label }}-${{ matrix.feature }}"
+          path: "/tmp/logs"

--- a/.github/workflows/archivematica-acceptance-tests.yml
+++ b/.github/workflows/archivematica-acceptance-tests.yml
@@ -12,21 +12,29 @@ on:
         default: "qa/0.x"
         required: true
         type: "string"
-      amauats_version:
+      at_version:
         description: "Archivematica Acceptance Test ref (branch, tag or SHA to checkout)"
         default: "qa/1.x"
         required: true
         type: "string"
 jobs:
   test:
-    name: "${{ matrix.vagrant-box.label }} / ${{ matrix.feature }}"
+    name: "${{ matrix.feature }} / ${{ matrix.vagrant_box.label }}"
     runs-on: "ubuntu-latest"
+    env:
+      am_version: "${{ inputs.am_version }}"
+      ss_version: "${{ inputs.ss_version }}"
+      at_version: "${{ inputs.at_version }}"
     strategy:
       fail-fast: false
       matrix:
-        vagrant-box:
+        vagrant_box:
           - id: "rockylinux/9"
             label: "rocky9"
+          - id: "rockylinux/8"
+            label: "rocky8"
+          - id: "almalinux/9"
+            label: "alma9"
           - id: "ubuntu/jammy64"
             label: "jammy"
         feature:
@@ -54,19 +62,19 @@ jobs:
         uses: "actions/checkout@v4"
         with:
           repository: "artefactual/archivematica"
-          ref: "${{ inputs.am_version }}"
+          ref: "${{ env.am_version }}"
           path: "${{ github.workspace }}/AM"
       - name: "Check out SS code"
         uses: "actions/checkout@v4"
         with:
           repository: "artefactual/archivematica-storage-service"
-          ref: "${{ inputs.ss_version }}"
+          ref: "${{ env.ss_version }}"
           path: "${{ github.workspace }}/SS"
       - name: "Check out AMAUATs code"
         uses: "actions/checkout@v4"
         with:
           repository: "artefactual-labs/archivematica-acceptance-tests"
-          ref: "${{ inputs.amauats_version }}"
+          ref: "${{ env.at_version }}"
           path: "${{ github.workspace }}/AMAUATs"
       - name: "Install Python"
         uses: "actions/setup-python@v5"
@@ -85,23 +93,16 @@ jobs:
       - name: "Install the vagrant-vbguest plugin"
         run: |
           vagrant plugin install vagrant-vbguest
-      - name: "Update vbox networks"
+      - name: "Update the VirtualBox networks file"
         run: |
           sudo mkdir -p /etc/vbox/
           echo "* 192.168.33.0/24" | sudo tee -a /etc/vbox/networks.conf
-      - name: "Start VM"
+      - name: "Start the VM"
         working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
         env:
-          VAGRANT_BOX: "${{ matrix.vagrant-box.id }}"
+          VAGRANT_BOX: "${{ matrix.vagrant_box.id }}"
         run: |
           vagrant up
-      - name: "Resize root partition in Rocky 9"
-        if: matrix.vagrant-box.id == 'rockylinux/9'
-        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
-        run: |
-          vagrant ssh -c 'echo "- +" | sudo sfdisk --no-reread -N 5 /dev/sda'
-          vagrant reload
-          vagrant ssh -c 'sudo xfs_growfs /dev/sda5'
       - name: "Install Archivematica"
         working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
         env:
@@ -111,9 +112,9 @@ jobs:
           ansible-playbook -i 192.168.33.2, playbook.yml \
               -u vagrant \
               --private-key ${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key \
-              -e "archivematica_src_am_version=${{ inputs.am_version }} archivematica_src_ss_version=${{ inputs.ss_version }}" \
+              -e "archivematica_src_am_version=${{ env.am_version }} archivematica_src_ss_version=${{ env.ss_version }}" \
               -v
-      - name: "Prepare VM for running AMAUATs"
+      - name: "Prepare the VM for running the AMAUATs"
         working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
         run: |
           vagrant ssh -c 'sudo usermod -a -G archivematica vagrant'
@@ -149,29 +150,28 @@ jobs:
               -D server_user=vagrant \
               -D transfer_source_path=/home/vagrant/archivematica-sampledata/TestTransfers/acceptance-tests \
               -D ssh_identity_file=${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key
-      - name: "Save logs on failure"
-        if: matrix.vagrant-box.id == 'ubuntu/jammy64' && (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled')
+      - name: "Save common logs on failure"
+        if: "${{ (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled') }}"
         working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
         run: |
           mkdir /tmp/logs
           vagrant ssh -c 'mkdir -p /tmp/logs/journalctl'
+          vagrant ssh -c 'sudo journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
+      - name: "Save logs on failure"
+        if: "${{ startsWith(matrix.vagrant_box.id, 'ubuntu/') && ((failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled')) }}"
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        run: |
           vagrant ssh -c 'sudo cp -r /var/log/{archivematica,mysql,elasticsearch,gearman-job-server,clamav,nginx} /tmp/logs'
-          vagrant ssh -c 'sudo journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
-          vagrant ssh -c 'sudo chown -R vagrant /tmp/logs'
-          scp \
-              -i ${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key \
-              -o "StrictHostKeyChecking=no" \
-              -r \
-              vagrant@192.168.33.2:/tmp/logs /tmp/logs
       - name: "Save logs on failure"
-        if: matrix.vagrant-box.id == 'rockylinux/9' && (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled')
+        if: "${{ (startsWith(matrix.vagrant_box.id, 'rockylinux/') || startsWith(matrix.vagrant_box.id, 'almalinux/')) && ((failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled')) }}"
         working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
         run: |
-          mkdir /tmp/logs
-          vagrant ssh -c 'mkdir -p /tmp/logs/journalctl'
-          vagrant ssh -c 'sudo cp -r /var/log/{archivematica,mysqld.log,elasticsearch,nginx} /tmp/logs'
-          vagrant ssh -c 'sudo journalctl -u archivematica-mcp-client --no-pager > /tmp/logs/journalctl/archivematica-mcp-client'
           vagrant ssh -c 'sudo journalctl -u clamd@scan --no-pager > /tmp/logs/journalctl/clamd'
+          vagrant ssh -c 'sudo cp -r /var/log/{archivematica,mysqld.log,elasticsearch,nginx} /tmp/logs'
+      - name: "Copy logs from VM"
+        if: "${{ (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled') }}"
+        working-directory: "${{ github.workspace }}/tests/archivematica-acceptance-tests"
+        run: |
           vagrant ssh -c 'sudo chown -R vagrant /tmp/logs'
           scp \
               -i ${{ github.workspace }}/tests/archivematica-acceptance-tests/.vagrant/machines/default/virtualbox/private_key \
@@ -182,5 +182,5 @@ jobs:
         if: "${{ (failure() && steps.amauat-run.outcome == 'failure') || (cancelled() && steps.amauat-run.outcome == 'cancelled') }}"
         uses: "actions/upload-artifact@v4"
         with:
-          name: "logs-${{ matrix.vagrant-box.label }}-${{ matrix.feature }}"
+          name: "logs-${{ matrix.vagrant_box.label }}-${{ matrix.feature }}"
           path: "/tmp/logs"

--- a/tests/archivematica-acceptance-tests/README.md
+++ b/tests/archivematica-acceptance-tests/README.md
@@ -6,6 +6,7 @@
 - VirtualBox 7.0
 - Python 3
 - Latest Google Chrome with chromedriver or Firefox with geckodriver
+- 7-Zip
 
 ## Tested Vagrant boxes
 
@@ -92,13 +93,14 @@ vagrant ssh -c 'sudo ln -s /home/vagrant /home/archivematica'
 Clone the AMAUATs repository:
 
 ```shell
-git clone https://github.com/artefactual-labs/archivematica-acceptance-tests
+git clone https://github.com/artefactual-labs/archivematica-acceptance-tests AMAUATs
+cd AMAUATs
 ```
 
 Install the AMAUATs requirements:
 
 ```shell
-python3 -m pip install -r archivematica-acceptance-tests/requirements.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Run any [feature file](https://github.com/artefactual-labs/archivematica-acceptance-tests/tree/qa/1.x/features/black_box)
@@ -125,5 +127,5 @@ env HEADLESS=1 behave -i create-aip.feature \
     -D home=vagrant \
     -D server_user=vagrant \
     -D transfer_source_path=/home/vagrant/archivematica-sampledata/TestTransfers/acceptance-tests \
-    -D ssh_identity_file=$PWD/.vagrant/machines/default/virtualbox/private_key
+    -D ssh_identity_file=$PWD/../.vagrant/machines/default/virtualbox/private_key
 ```

--- a/tests/archivematica-acceptance-tests/README.md
+++ b/tests/archivematica-acceptance-tests/README.md
@@ -1,0 +1,129 @@
+# Archivematica Acceptance Tests (AMAUATs)
+
+## Software requirements
+
+- Vagrant 2.4.1 (with vagrant-vbguest plugin)
+- VirtualBox 7.0
+- Python 3
+- Latest Google Chrome with chromedriver or Firefox with geckodriver
+
+## Tested Vagrant boxes
+
+This playbook has been tested with Vagrant 2.4.1 and VirtualBox 7.0.14 r161095
+using any of the following Vagrant boxes and versions:
+
+- rockylinux/9 (v3.0.0)
+- rockylinux/8 (v9.0.0)
+- almalinux/9 (v9.3.20231118)
+- ubuntu/jammy64 (v20240403.0.0)
+
+## Provisioning the VM
+
+Install the `vagrant-vbguest` plugin:
+
+```shell
+vagrant plugin install vagrant-vbguest
+```
+
+Add the VM IP address to the VirtualBox networks file:
+
+```shell
+sudo mkdir -p /etc/vbox/
+echo "* 192.168.33.0/24" | sudo tee -a /etc/vbox/networks.conf
+```
+
+Set the `VAGRANT_BOX` environment variable with the ID of a Vagrant Cloud
+box. The `ubuntu/jammy64` box is used by default if `VAGRANT_BOX` is not set:
+
+```shell
+export VAGRANT_BOX=ubuntu/jammy64
+```
+
+Start the VM:
+
+```shell
+vagrant up
+```
+
+## Installing Archivematica
+
+Create a virtual environment and activate it:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install `ansible` and `behave`:
+
+```shell
+python3 -m pip install ansible behave
+```
+
+Install the playbook requirements:
+
+```shell
+ansible-galaxy install -f -p roles/ -r requirements.yml
+```
+
+Run the installation playbook:
+
+```shell
+ansible-playbook -i 192.168.33.2, playbook.yml \
+    -u vagrant \
+    --private-key $PWD/.vagrant/machines/default/virtualbox/private_key \
+    -v
+```
+
+Add the `vagrant` user to the `archivematica` group so it can copy AIPs
+from the shared directory:
+
+```shell
+vagrant ssh -c 'sudo usermod -a -G archivematica vagrant'
+```
+
+The AMAUATs expect the Archivematica sample data to be in the
+`/home/archivematica` directory:
+
+```shell
+vagrant ssh -c 'sudo ln -s /home/vagrant /home/archivematica'
+```
+
+Clone the AMAUATs repository:
+
+```shell
+git clone https://github.com/artefactual-labs/archivematica-acceptance-tests
+```
+
+Install the AMAUATs requirements:
+
+```shell
+python3 -m pip install -r archivematica-acceptance-tests/requirements.txt
+```
+
+Run any [feature file](https://github.com/artefactual-labs/archivematica-acceptance-tests/tree/qa/1.x/features/black_box)
+in the AMAUATs using its filename. This example shows how to run the
+`create-aip.feature` file with `Chrome`.
+
+```shell
+env HEADLESS=1 behave -i create-aip.feature \
+    -v \
+    --no-capture \
+    --no-capture-stderr \
+    --no-logcapture \
+    --no-skipped \
+    -D am_version=1.9 \
+    -D driver_name=Chrome \
+    -D am_username=admin \
+    -D am_password=archivematica \
+    -D am_url=http://192.168.33.2/ \
+    -D am_api_key="this_is_the_am_api_key" \
+    -D ss_username=admin \
+    -D ss_password=archivematica \
+    -D ss_api_key="this_is_the_ss_api_key" \
+    -D ss_url=http://192.168.33.2:8000/ \
+    -D home=vagrant \
+    -D server_user=vagrant \
+    -D transfer_source_path=/home/vagrant/archivematica-sampledata/TestTransfers/acceptance-tests \
+    -D ssh_identity_file=$PWD/.vagrant/machines/default/virtualbox/private_key
+```

--- a/tests/archivematica-acceptance-tests/Vagrantfile
+++ b/tests/archivematica-acceptance-tests/Vagrantfile
@@ -2,14 +2,56 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
+
+  # Detect the Vagrant Cloud box ID from environment variables.
   config.vm.box = ENV.fetch("VAGRANT_BOX", "ubuntu/jammy64")
-  config.vm.disk :disk, size: "40GB", primary: true
-  config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.network "private_network", ip: "192.168.33.2"
+
+  # Set VM specifications.
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "8192"
     vb.cpus = "2"
+    if ENV.fetch("VAGRANT_BOX", "").include? "rockylinux/"
+      vb.customize ["modifyvm", :id, "--firmware", "efi64"]
+    end
   end
-  # This requires the vagrant-vbguest plugin
+
+  # Turn off the default synced folder.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Set a fixed IP address.
+  config.vm.network "private_network", ip: "192.168.33.2"
+
+  # VirtualBox Guest Additions are not needed for installing Archivematica.
+  # This requires the vagrant-vbguest plugin to be installed, but it works
+  # accross all the supported Vagrant boxes.
   config.vbguest.auto_update = false
+
+  # The disk on these boxes has less than 40GB which might be insufficient for
+  # running some of the larger feature files of the acceptance tests.
+  # This resizes it (and its root partition) to 40GB.
+  if ENV.fetch("VAGRANT_BOX", "").start_with?("rockylinux/", "almalinux/")
+    config.vm.disk :disk, size: "40GB", primary: true
+    config.vm.provision "shell", inline: $resize_root_filesystem
+  end
+
+  # The almalinux/9 box only comes with the C.UTF-8 locale but Archivematica
+  # services use the en_US.UTF-8 locale, so this installs it.
+  if ENV.fetch("VAGRANT_BOX", "").start_with?("almalinux/")
+    config.vm.provision "shell", inline: "yum install -y glibc-langpack-en"
+  end
+
 end
+
+$resize_root_filesystem = <<-SCRIPT
+# The root partition has the highest number in the disk.
+export ROOT_PARTITION=$(grep -c "sda[0-9]" /proc/partitions)
+
+# Resize the root partition.
+echo "- +" | sudo sfdisk --no-reread -N "${ROOT_PARTITION}" /dev/sda
+
+# Read the new partition table.
+sudo partprobe
+
+# Resize the filesystem in the root partition.
+sudo xfs_growfs "/dev/sda${ROOT_PARTITION}"
+SCRIPT

--- a/tests/archivematica-acceptance-tests/Vagrantfile
+++ b/tests/archivematica-acceptance-tests/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = ENV.fetch("VAGRANT_BOX", "ubuntu/jammy64")
+  config.vm.disk :disk, size: "40GB", primary: true
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.network "private_network", ip: "192.168.33.2"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "8192"
+    vb.cpus = "2"
+  end
+  # This requires the vagrant-vbguest plugin
+  config.vbguest.auto_update = false
+end

--- a/tests/archivematica-acceptance-tests/playbook.yml
+++ b/tests/archivematica-acceptance-tests/playbook.yml
@@ -1,0 +1,34 @@
+---
+- hosts: "all"
+
+  pre_tasks:
+
+    - include_vars: "vars.yml"
+      tags:
+        - "always"
+
+    - name: "Change home dir perms (to make transfer source visible)"
+      command: "chmod 755 $HOME"
+      become: "no"
+
+  roles:
+
+    - role: "artefactual.elasticsearch"
+      become: "yes"
+
+    - role: "artefactual.percona"
+      become: "yes"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+
+    - role: "artefactual.clamav"
+      become: "yes"
+
+    - role: "artefactual.nginx"
+      become: "yes"
+
+    - role: "artefactual.archivematica-src"
+      become: "yes"
+      tags:
+        - "archivematica-src"

--- a/tests/archivematica-acceptance-tests/requirements.yml
+++ b/tests/archivematica-acceptance-tests/requirements.yml
@@ -1,0 +1,25 @@
+---
+
+- src: "https://github.com/artefactual-labs/ansible-elasticsearch"
+  version: "master"
+  name: "artefactual.elasticsearch"
+
+- src: "https://github.com/artefactual-labs/ansible-percona"
+  version: "master"
+  name: "artefactual.percona"
+
+- src: "https://github.com/artefactual-labs/ansible-gearman"
+  version: "master"
+  name: "artefactual.gearman"
+
+- src: "https://github.com/artefactual-labs/ansible-nginx"
+  version: "master"
+  name: "artefactual.nginx"
+
+- src: "https://github.com/artefactual-labs/ansible-archivematica-src"
+  version: "qa/1.x"
+  name: "artefactual.archivematica-src"
+
+- src: "https://github.com/artefactual-labs/ansible-clamav"
+  version: "master"
+  name: "artefactual.clamav"

--- a/tests/archivematica-acceptance-tests/vars.yml
+++ b/tests/archivematica-acceptance-tests/vars.yml
@@ -1,0 +1,76 @@
+---
+
+# archivematica-src role
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"
+archivematica_src_configure_am_api_key: "this_is_the_am_api_key"
+archivematica_src_configure_am_site_url: "http://192.168.33.2"
+
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_api_key: "this_is_the_ss_api_key"
+archivematica_src_configure_ss_url: "http://192.168.33.2:8000"
+archivematica_src_configure_ss_email: "admin@example.com"
+
+archivematica_src_am_db_password: "aaGKHyMls.20ki$"
+archivematica_src_ss_db_password: "aaGKHyMls.20ki$"
+
+# By default the archivematica-src role sets `MCP` and `SS` as the database
+# names and a single `archivematica` user for both services. The
+# artefactual.percona overwrites existing user privileges when it creates
+# databases (it should set `append_privs: true` on the `mysql_user` module call)
+# so the SS database privileges overwrite the MCP ones. Setting different
+# users for each database works around  this issue.
+archivematica_src_am_db_user: "archivematica"
+archivematica_src_ss_db_user: "ss"
+
+# percona role
+
+mysql_version_major: "8"
+mysql_version_minor: "0"
+
+mysql_root_password: "aaGKHyMls.20ki$"
+
+mysql_databases:
+  - name: "{{ archivematica_src_am_db_name }}"
+    collation: "{{ archivematica_src_am_db_collation }}"
+    encoding: "{{ archivematica_src_am_db_encoding }}"
+  - name: "{{ archivematica_src_ss_db_name }}"
+    collation: "{{ archivematica_src_ss_db_collation }}"
+    encoding: "{{ archivematica_src_ss_db_encoding }}"
+
+mysql_users:
+  - name: "{{ archivematica_src_am_db_user }}"
+    pass: "{{ archivematica_src_am_db_password }}"
+    priv: "{{ archivematica_src_am_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_am_db_host }}"
+  - name: "{{ archivematica_src_ss_db_user }}"
+    pass: "{{ archivematica_src_ss_db_password }}"
+    priv: "{{ archivematica_src_ss_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_ss_db_host }}"
+
+archivematica_src_ss_environment:
+  SS_DB_URL: "mysql://{{ archivematica_src_ss_db_user }}:{{ archivematica_src_ss_db_password }}@{{ archivematica_src_ss_db_host }}:{{ archivematica_src_ss_db_port }}/{{ archivematica_src_ss_db_name }}"
+
+# Enable XML metadata validation
+
+archivematica_src_am_mcpclient_environment:
+  ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_METADATA_XML_VALIDATION_ENABLED: "true"
+  METADATA_XML_VALIDATION_SETTINGS_FILE: "/home/{{ ansible_user_id }}/archivematica-sampledata/xml-validation/xml_validation.py"
+
+# Disable FITS
+
+archivematica_src_configure_fpcommand:
+  FITS:
+    enabled: '0'
+    field_name: 'description'
+
+archivematica_src_configure_fprule:
+  c3b06895-ef9d-401e-8c51-ac585f955655:
+    enabled: '0'
+    field_name: 'uuid'


### PR DESCRIPTION
This adds a GitHub workflow that provisions a VM with Vagrant to install Archivematica using the Ansible playbooks. The Acceptance Tests features are then run with `behave` against the new VM.

The workflow can be triggered manually from the Actions tab and it accepts branches, tags or commit hashes for the Archivematica, Storage Service and Acceptance Tests checkouts.

![Captura desde 2024-04-11 16-06-19](https://github.com/artefactual/deploy-pub/assets/560781/6b370356-ff6c-4505-978a-040f83a3e5fa)
