### PR TITLE
Add DIP upload test workflow

### DIFF
--- a/.github/workflows/dip-upload.yml
+++ b/.github/workflows/dip-upload.yml
@@ -1,0 +1,171 @@
+name: "DIP Upload Test"
+on:
+  workflow_dispatch:
+    inputs:
+      am_version:
+        description: "Archivematica ref (branch, tag or SHA to checkout)"
+        default: "qa/1.x"
+        required: true
+        type: "string"
+      ss_version:
+        description: "Archivematica Storage Service ref (branch, tag or SHA to checkout)"
+        default: "qa/0.x"
+        required: true
+        type: "string"
+      atom_version:
+        description: "AtoM ref (branch, tag or SHA to checkout)"
+        default: "qa/2.x"
+        required: true
+        type: "string"
+jobs:
+  test:
+    name: "DIP upload test"
+    runs-on: "ubuntu-latest"
+    env:
+      am_version: "${{ inputs.am_version }}"
+      ss_version: "${{ inputs.ss_version }}"
+      atom_version: "${{ inputs.atom_version }}"
+      am_vagrant_box_id: "ubuntu/jammy64"
+      atom_vagrant_box_id: "ubuntu/focal64"
+    steps:
+      - name: "Check out code"
+        uses: "actions/checkout@v4"
+      - name: "Create Vagrant boxes directory"
+        run: |
+          mkdir -p /home/runner/.vagrant.d/boxes
+      - name: "Cache Vagrant boxes"
+        uses: "actions/cache@v4"
+        with:
+          path: "/home/runner/.vagrant.d/boxes"
+          key: "${{ runner.os }}-boxes"
+      - name: "Install Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "3.9"
+      - name: "Install Vagrant"
+        run: |
+          wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt update && sudo apt install vagrant
+      - name: "Install VirtualBox"
+        run: |
+          wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian jammy contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+          sudo apt update && sudo apt install virtualbox-7.0
+      - name: "Downgrade VirtualBox"
+        run: |
+          sudo apt-get purge virtualbox-7.0
+          wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
+          sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
+      - name: "Install the vagrant-vbguest plugin"
+        run: |
+          vagrant plugin install vagrant-vbguest
+      - name: "Update the VirtualBox networks file"
+        run: |
+          sudo mkdir -p /etc/vbox/
+          echo "* 192.168.33.0/24" | sudo tee -a /etc/vbox/networks.conf
+      - name: "Install ansible"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install ansible==8.5.0 ansible-core==2.15.5
+      - name: "Start the Archivematica VM"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        env:
+          VAGRANT_BOX: "${{ env.am_vagrant_box_id }}"
+        run: |
+          vagrant up archivematica
+      - name: "Install Archivematica"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+        run: |
+          source .venv/bin/activate
+          ansible-galaxy install -f -p roles/ -r requirements.yml
+          ansible-playbook -i 192.168.33.2, archivematica.yml \
+              -u vagrant \
+              --private-key ${{ github.workspace }}/tests/dip-upload/.vagrant/machines/archivematica/virtualbox/private_key \
+              -e "archivematica_src_am_version=${{ env.am_version }} archivematica_src_ss_version=${{ env.ss_version }}" \
+              -v
+      - name: "Add the vagrant user to the archivematica group"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          vagrant ssh archivematica -c 'sudo usermod -a -G archivematica vagrant'
+      - name: "Get the archivematica SSH public key"
+        id: archivematica_ssh_pub_key
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          echo "key=$(vagrant ssh archivematica -c 'sudo cat /var/lib/archivematica/.ssh/id_rsa.pub')" >> $GITHUB_OUTPUT
+      - name: "Start the AtoM VM"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        env:
+          VAGRANT_BOX: "${{ env.atom_vagrant_box_id }}"
+        run: |
+          vagrant up atom
+      - name: "Install AtoM"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+        run: |
+          source .venv/bin/activate
+          ansible-playbook -i 192.168.33.3, atom.yml \
+              -u vagrant \
+              --private-key ${{ github.workspace }}/tests/dip-upload/.vagrant/machines/atom/virtualbox/private_key \
+              -e "atom_repository_version=${{ env.atom_version }} archivematica_ssh_pub_key='${{ steps.archivematica_ssh_pub_key.outputs.key }}'" \
+              -v
+      - name: "Call an Archivematica API endpoint"
+        run: |
+          curl \
+              --header "Authorization: ApiKey admin:this_is_the_am_api_key" \
+              http://192.168.33.2/api/processing-configuration/
+      - name: "Call a Storage Service API endpoint"
+        run: |
+          curl \
+              --header "Authorization: ApiKey admin:this_is_the_ss_api_key" \
+              http://192.168.33.2:8000/api/v2/pipeline/
+      - name: "Call an AtoM API endpoint"
+        run: |
+          curl \
+              --header "REST-API-Key: this_is_the_atom_dip_upload_api_key" \
+              http://192.168.33.3/index.php/api/informationobjects
+      - name: "Create a processing configuration for DIP upload"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          vagrant ssh archivematica -c "sudo -u archivematica cp /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/{automated,dipupload}ProcessingMCP.xml"
+      - name: "Update the DIP upload processing configuration"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          # Change 'Normalize for preservation' to 'Normalize for preservation and access'
+          vagrant ssh archivematica -c "sudo -u archivematica sed --in-place 's|612e3609-ce9a-4df6-a9a3-63d634d2d934|b93cecd4-71f2-4e28-bc39-d32fd62c5a94|g' /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/dipuploadProcessingMCP.xml"
+          # Change 'Do not upload DIP' to 'Upload DIP to AtoM/Binder'
+          vagrant ssh archivematica -c "sudo -u archivematica sed --in-place 's|6eb8ebe7-fab3-4e4c-b9d7-14de17625baa|0fe9842f-9519-4067-a691-8a363132ae24|g' /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/dipuploadProcessingMCP.xml"
+      - name: "Import Atom sample data"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony csv:import /usr/share/nginx/atom/lib/task/import/example/isad/example_information_objects_isad.csv"
+          vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony propel:build-nested-set"
+          vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony cc"
+          vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony search:populate"
+      - name: "Start a transfer and upload the DIP to the sample archival description"
+        run: |
+          curl \
+              --header "Authorization: ApiKey admin:this_is_the_am_api_key" \
+              --request POST \
+              --data "{ \
+                  \"name\": \"dip-upload-test\", \
+                  \"path\": \"$(echo -n '/home/vagrant/archivematica-sampledata/SampleTransfers/DemoTransferCSV' | base64 -w 0)\", \
+                  \"type\": \"standard\", \
+                  \"processing_config\": \"dipupload\", \
+                  \"access_system_id\": \"example-item\" \
+              }" \
+              http://192.168.33.2/api/v2beta/package
+      - name: "Wait for the transfer to finish"
+        run: |
+          sleep 120
+      - name: "Verify a digital object was uploaded and attached to the sample archival description"
+        run: |
+          curl \
+              --header "REST-API-Key: this_is_the_atom_dip_upload_api_key" \
+              --silent \
+              http://192.168.33.3/index.php/api/informationobjects/beihai-guanxi-china-1988 | python3 -m json.tool | grep '"parent": "example-item"'

--- a/tests/dip-upload/README.md
+++ b/tests/dip-upload/README.md
@@ -1,0 +1,184 @@
+# DIP upload test
+
+## Software requirements
+
+- Vagrant 2.4.1 (with vagrant-vbguest plugin)
+- VirtualBox 7.0
+- Python 3
+- curl
+
+## Tested Vagrant boxes
+
+This playbook has been tested with Vagrant 2.4.1 and VirtualBox 7.0.14 r161095
+using any of the following Vagrant boxes and versions:
+
+- Archivematica: ubuntu/jammy64 (v20240403.0.0)
+- AtoM: ubuntu/focal64 (v20231003.0.0)
+
+## Installing Ansible
+
+Create a virtual environment and activate it:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install `ansible` and `ansible-core` (these versions are compatible with
+symbolic links which are used in the the artefactual-atom role):
+
+```shell
+python3 -m pip install ansible==8.5.0 ansible-core==2.15.5
+```
+
+Install the playbook requirements:
+
+```shell
+ansible-galaxy install -f -p roles/ -r requirements.yml
+```
+
+## Setting up VirtualBox
+
+Install the `vagrant-vbguest` plugin:
+
+```shell
+vagrant plugin install vagrant-vbguest
+```
+
+Add the VMs IP network to the VirtualBox networks file:
+
+```shell
+sudo mkdir -p /etc/vbox/
+echo "* 192.168.33.0/24" | sudo tee -a /etc/vbox/networks.conf
+```
+
+## Provisioning the Archivematica VM
+
+Start the VM passing the `VAGRANT_BOX` environment variable with the ID of the
+Ubuntu 22.04 Vagrant Cloud:
+
+```shell
+env VAGRANT_BOX=ubuntu/jammy64 vagrant up archivematica
+```
+
+Run the Archivematica installation playbook:
+
+```shell
+ansible-playbook -i 192.168.33.2, archivematica.yml \
+    -u vagrant \
+    --private-key $PWD/.vagrant/machines/archivematica/virtualbox/private_key \
+    -v
+```
+
+Add the `vagrant` user to the `archivematica` group so it can copy AIPs
+from the shared directory:
+
+```shell
+vagrant ssh archivematica -c 'sudo usermod -a -G archivematica vagrant'
+```
+
+Get the SSH public key of the `archivematica` user so we can use it when
+provisioning the AtoM VM:
+
+```shell
+AM_SSH_PUB_KEY=$(vagrant ssh archivematica -c 'sudo cat /var/lib/archivematica/.ssh/id_rsa.pub')
+```
+
+## Provisioning the AtoM VM
+
+Start the VM passing the `VAGRANT_BOX` environment variable with the ID of the
+Ubuntu 20.04 Vagrant Cloud:
+
+```shell
+env VAGRANT_BOX=ubuntu/focal64 vagrant up atom
+```
+
+Run the AtoM installation playbook passing the `archivematica_ssh_pub_key`
+variable with the contents of `$AM_SSH_PUB_KEY`:
+
+```shell
+ansible-playbook -i 192.168.33.3, atom.yml \
+    -u vagrant \
+    --private-key $PWD/.vagrant/machines/atom/virtualbox/private_key \
+    -e "archivematica_ssh_pub_key='$AM_SSH_PUB_KEY'" \
+    -v
+```
+
+## Testing the Archivematica installation
+
+Call an Archivematica API endpoint:
+
+```shell
+curl --header "Authorization: ApiKey admin:this_is_the_am_api_key" http://192.168.33.2/api/processing-configuration/
+```
+
+Call a Storage Service API endpoint:
+
+```shell
+curl --header "Authorization: ApiKey admin:this_is_the_ss_api_key" http://192.168.33.2:8000/api/v2/pipeline/
+```
+
+## Testing the AtoM installation
+
+Call an AtoM API endpoint:
+
+```shell
+curl --header "REST-API-Key: this_is_the_atom_dip_upload_api_key" http://192.168.33.3/index.php/api/informationobjects
+```
+
+## Testing DIP upload
+
+Create a processing configuration for DIP upload:
+
+```shell
+vagrant ssh archivematica -c "sudo -u archivematica cp /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/{automated,dipupload}ProcessingMCP.xml"
+```
+
+Update the DIP upload processing configuration:
+
+```shell
+# Change 'Normalize for preservation' to 'Normalize for preservation and access'
+vagrant ssh archivematica -c "sudo -u archivematica sed --in-place 's|612e3609-ce9a-4df6-a9a3-63d634d2d934|b93cecd4-71f2-4e28-bc39-d32fd62c5a94|g' /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/dipuploadProcessingMCP.xml"
+# Change 'Do not upload DIP' to 'Upload DIP to AtoM/Binder'
+vagrant ssh archivematica -c "sudo -u archivematica sed --in-place 's|6eb8ebe7-fab3-4e4c-b9d7-14de17625baa|0fe9842f-9519-4067-a691-8a363132ae24|g' /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/dipuploadProcessingMCP.xml"
+```
+
+Import Atom sample data:
+
+```shell
+vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony csv:import /usr/share/nginx/atom/lib/task/import/example/isad/example_information_objects_isad.csv"
+vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony propel:build-nested-set"
+vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony cc"
+vagrant ssh atom -c "cd /usr/share/nginx/atom/ && sudo -u www-data php -d memory_limit=-1 symfony search:populate"
+```
+
+Start a transfer and upload the DIP to the sample archival description:
+
+```shell
+curl \
+    --header "Authorization: ApiKey admin:this_is_the_am_api_key" \
+    --request POST \
+    --data "{ \
+        \"name\": \"dip-upload-test\", \
+        \"path\": \"$(echo -n '/home/vagrant/archivematica-sampledata/SampleTransfers/DemoTransferCSV' | base64 -w 0)\", \
+        \"type\": \"standard\", \
+        \"processing_config\": \"dipupload\", \
+        \"access_system_id\": \"example-item\" \
+    }" \
+    http://192.168.33.2/api/v2beta/package
+```
+
+Wait for the transfer to finish:
+
+```shell
+sleep 120
+```
+
+Verify a digital object was uploaded and attached to the sample archival description:
+
+```shell
+curl \
+    --header "REST-API-Key: this_is_the_atom_dip_upload_api_key" \
+    --silent \
+    http://192.168.33.3/index.php/api/informationobjects/beihai-guanxi-china-1988 | python3 -m json.tool | grep '"parent": "example-item"'
+```

--- a/tests/dip-upload/Vagrantfile
+++ b/tests/dip-upload/Vagrantfile
@@ -1,0 +1,64 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  # Detect the Vagrant Cloud box ID from environment variables.
+  config.vm.box = ENV.fetch("VAGRANT_BOX", "ubuntu/jammy64")
+
+  # Set VM specifications.
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "8192"
+    vb.cpus = "2"
+    if ENV.fetch("VAGRANT_BOX", "").include? "rockylinux/"
+      vb.customize ["modifyvm", :id, "--firmware", "efi64"]
+    end
+  end
+
+  # Turn off the default synced folder.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.define "archivematica" do |archivematica|
+    # Set a fixed IP address.
+    archivematica.vm.network "private_network", ip: "192.168.33.2"
+  end
+
+  config.vm.define "atom" do |atom|
+    # Set a fixed IP address.
+    atom.vm.network "private_network", ip: "192.168.33.3"
+  end
+
+  # VirtualBox Guest Additions are not needed for installing Archivematica.
+  # This requires the vagrant-vbguest plugin to be installed, but it works
+  # accross all the supported Vagrant boxes.
+  config.vbguest.auto_update = false
+
+  # The disk on these boxes has less than 40GB which might be insufficient for
+  # running some of the larger feature files of the acceptance tests.
+  # This resizes it (and its root partition) to 40GB.
+  if ENV.fetch("VAGRANT_BOX", "").start_with?("rockylinux/", "almalinux/")
+    config.vm.disk :disk, size: "40GB", primary: true
+    config.vm.provision "shell", inline: $resize_root_filesystem
+  end
+
+  # The almalinux/9 box only comes with the C.UTF-8 locale but Archivematica
+  # services use the en_US.UTF-8 locale, so this installs it.
+  if ENV.fetch("VAGRANT_BOX", "").start_with?("almalinux/")
+    config.vm.provision "shell", inline: "yum install -y glibc-langpack-en"
+  end
+
+end
+
+$resize_root_filesystem = <<-SCRIPT
+# The root partition has the highest number in the disk.
+export ROOT_PARTITION=$(grep -c "sda[0-9]" /proc/partitions)
+
+# Resize the root partition.
+echo "- +" | sudo sfdisk --no-reread -N "${ROOT_PARTITION}" /dev/sda
+
+# Read the new partition table.
+sudo partprobe
+
+# Resize the filesystem in the root partition.
+sudo xfs_growfs "/dev/sda${ROOT_PARTITION}"
+SCRIPT

--- a/tests/dip-upload/archivematica-vars.yml
+++ b/tests/dip-upload/archivematica-vars.yml
@@ -1,0 +1,92 @@
+---
+
+# archivematica-src role
+
+archivematica_src_configure_dashboard: "yes"
+archivematica_src_configure_ss: "yes"
+
+archivematica_src_configure_am_user: "admin"
+archivematica_src_configure_am_password: "archivematica"
+archivematica_src_configure_am_email: "admin@example.com"
+archivematica_src_configure_am_api_key: "this_is_the_am_api_key"
+archivematica_src_configure_am_site_url: "http://192.168.33.2"
+
+archivematica_src_configure_ss_user: "admin"
+archivematica_src_configure_ss_password: "archivematica"
+archivematica_src_configure_ss_api_key: "this_is_the_ss_api_key"
+archivematica_src_configure_ss_url: "http://192.168.33.2:8000"
+archivematica_src_configure_ss_email: "admin@example.com"
+
+archivematica_src_am_db_password: "aaGKHyMls.20ki$"
+archivematica_src_ss_db_password: "aaGKHyMls.20ki$"
+
+# By default the archivematica-src role sets `MCP` and `SS` as the database
+# names and a single `archivematica` user for both services. The
+# artefactual.percona overwrites existing user privileges when it creates
+# databases (it should set `append_privs: true` on the `mysql_user` module call)
+# so the SS database privileges overwrite the MCP ones. Setting different
+# users for each database works around  this issue.
+archivematica_src_am_db_user: "archivematica"
+archivematica_src_ss_db_user: "ss"
+
+# percona role
+
+mysql_version_major: "8"
+mysql_version_minor: "0"
+
+mysql_root_password: "aaGKHyMls.20ki$"
+
+mysql_databases:
+  - name: "{{ archivematica_src_am_db_name }}"
+    collation: "{{ archivematica_src_am_db_collation }}"
+    encoding: "{{ archivematica_src_am_db_encoding }}"
+  - name: "{{ archivematica_src_ss_db_name }}"
+    collation: "{{ archivematica_src_ss_db_collation }}"
+    encoding: "{{ archivematica_src_ss_db_encoding }}"
+
+mysql_users:
+  - name: "{{ archivematica_src_am_db_user }}"
+    pass: "{{ archivematica_src_am_db_password }}"
+    priv: "{{ archivematica_src_am_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_am_db_host }}"
+  - name: "{{ archivematica_src_ss_db_user }}"
+    pass: "{{ archivematica_src_ss_db_password }}"
+    priv: "{{ archivematica_src_ss_db_name }}.*:ALL,GRANT"
+    host: "{{ archivematica_src_ss_db_host }}"
+
+archivematica_src_ss_environment:
+  SS_DB_URL: "mysql://{{ archivematica_src_ss_db_user }}:{{ archivematica_src_ss_db_password }}@{{ archivematica_src_ss_db_host }}:{{ archivematica_src_ss_db_port }}/{{ archivematica_src_ss_db_name }}"
+
+# Enable XML metadata validation
+
+archivematica_src_am_mcpclient_environment:
+  ARCHIVEMATICA_MCPCLIENT_MCPCLIENT_METADATA_XML_VALIDATION_ENABLED: "true"
+  METADATA_XML_VALIDATION_SETTINGS_FILE: "/home/{{ ansible_user_id }}/archivematica-sampledata/xml-validation/xml_validation.py"
+
+# Disable FITS
+
+archivematica_src_configure_fpcommand:
+  FITS:
+    enabled: '0'
+    field_name: 'description'
+
+archivematica_src_configure_fprule:
+  c3b06895-ef9d-401e-8c51-ac585f955655:
+    enabled: '0'
+    field_name: 'uuid'
+
+# DIP upload
+
+# The ansible-archivematica-src role supports configuring dashboard settings,
+# but it connects to the AtoM host automatically to set SSH credentials. In the
+# two VMs scenario of this test, the AtoM host is provisioned after the
+# Archivematica host so that approach does not work.
+#
+# Instead, these custom settings are populated in the post tasks of the
+# Archivematica provisioning playbook.
+custom_archivematica_src_configure_dashboardsettings:
+  url: "http://192.168.33.3"
+  rsync_target: "192.168.33.3:/home/archivematica/atom_sword_deposit"
+  email: "dip_upload@example.com"
+  password: "dip_upload@example.com"
+  key: "this_is_the_atom_dip_upload_api_key"

--- a/tests/dip-upload/archivematica.yml
+++ b/tests/dip-upload/archivematica.yml
@@ -1,0 +1,68 @@
+---
+- hosts: "all"
+
+  pre_tasks:
+
+    - include_vars: "archivematica-vars.yml"
+      tags:
+        - "always"
+
+    - name: "Change home dir perms (to make transfer source visible)"
+      command: "chmod 755 $HOME"
+      become: "no"
+
+  roles:
+
+    - role: "artefactual.elasticsearch"
+      become: "yes"
+
+    - role: "artefactual.percona"
+      become: "yes"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+
+    - role: "artefactual.clamav"
+      become: "yes"
+
+    - role: "artefactual.nginx"
+      become: "yes"
+
+    - role: "artefactual.archivematica-src"
+      become: "yes"
+      tags:
+        - "archivematica-src"
+
+  post_tasks:
+
+    - name: "Configure Dashboard settings"
+      command: >
+        mysql --user="{{ archivematica_src_am_db_user }}"
+              --password="{{ archivematica_src_am_db_password }}"
+              --host="{{ archivematica_src_am_db_host }}"
+              "{{ archivematica_src_am_db_name }}"
+              --batch --skip-column-names
+              --execute="update DashboardSettings set value=\"{{ item.value }}\" where name=\"{{ item.key }}\";"
+      with_dict: "{{ custom_archivematica_src_configure_dashboardsettings }}"
+      no_log: True
+      when:
+        - archivematica_src_configure_dashboard|bool
+        - custom_archivematica_src_configure_dashboardsettings is defined
+
+    - name: "Configure AtoM DIP Upload in AM host"
+      block:
+        - name: "Create rsa for user archivematica"
+          user:
+            name: "archivematica"
+            generate_ssh_key: "yes"
+            ssh_key_file: ".ssh/id_rsa"
+
+        - name: "Use StrictHostKeyChecking=no ssh option for archivematica user"
+          lineinfile:
+            create: "yes"
+            path: "/var/lib/archivematica/.ssh/config"
+            owner: "archivematica"
+            group: "archivematica"
+            mode: "0600"
+            line: "StrictHostKeyChecking no"
+      become: true

--- a/tests/dip-upload/atom-vars.yml
+++ b/tests/dip-upload/atom-vars.yml
@@ -1,0 +1,132 @@
+---
+
+# atom role
+
+atom_repository_version: "qa/2.x"
+
+atom_user_email: "demo@example.com"
+atom_user_username: "demo"
+atom_user_password: "demo"
+
+atom_config_db_hostname: "127.0.0.1"
+atom_config_db_name: "atom"
+atom_config_db_username: "atom-user"
+atom_config_db_password: "aaGKHyMls.20ki$"
+
+atom_mysql_user_name: "{{ atom_config_db_username }}"
+atom_mysql_user_pass: "{{ atom_config_db_password }}"
+atom_mysql_user_priv: "atom.*:ALL,GRANT"
+atom_mysql_user_host: "%"
+
+atom_csrf_protection: "yes"
+
+atom_auto_init: "yes"
+
+atom_sword_deposit_dir: "/home/archivematica/atom_sword_deposit"
+
+atom_dip_upload_atom_database: "atom"
+atom_dip_upload_atom_user: "dip_upload"
+atom_dip_upload_atom_email: "dip_upload@example.com"
+atom_dip_upload_atom_password: "dip_upload@example.com"
+atom_dip_upload_atom_api_key: "this_is_the_atom_dip_upload_api_key"
+
+# nginx role
+
+nginx_configs:
+  atom_backend:
+    - upstream atom {
+        server unix:/var/run/php-fpm.atom.sock;
+      }
+
+nginx_sites:
+  atom:
+    - listen 80
+    - server_name _
+    - '{%- if atom_revision_directory|bool -%}
+      set $atom_path {{ atom_path }}/{{ atom_revision_directory_latest_symlink_dir }}
+      {%-   else -%}
+      set $atom_path {{ atom_path }}
+      {%- endif -%}'
+    - root $atom_path
+    - client_max_body_size {{ atom_pool_php_post_max_size | default('520M') }}
+    - proxy_max_temp_file_size {{ atom_nginx_proxy_max_temp_file_size | default('1024m') }}
+    - '{% if nginx_auth_basic_files|length > 0 -%}
+      satisfy any;
+      allow 127.0.0.1;
+      {%-   if atom_http_auth_allowed_hosts is defined and atom_http_auth_allowed_hosts| length >0 -%}
+        {%-     for allowed_hosts in atom_http_auth_allowed_hosts -%}
+          allow {{ allowed_hosts }};
+        {%-     endfor -%}
+      {%-   endif -%}
+      deny all;
+      auth_basic "Restricted";
+      auth_basic_user_file /etc/nginx/auth_basic/htpasswd.{{ site | default("atom") }}
+      {%- endif -%}'
+    - location ~* ^/(css|dist|js|images|plugins|vendor)/.*\.(css|gif|ico|jpg|js|map|pdf|png|svg|ttf|woff|woff2)$ { }
+    - location ~* ^/(downloads)/.*\.(csv|html|pdf|rtf|xml|zip)$ { }
+    - location ~ ^/(ead.dtd|favicon.ico|robots.txt|sitemap.*)$ { }
+    - location / {
+        try_files $uri /index.php?$args;
+        if (-f $request_filename) {
+           return 403;
+        }
+      }
+    - location ~* /uploads/r/(.*)/conf/ { }
+    - location ~* ^/uploads/r/(.*)$ {
+        include /etc/nginx/fastcgi_params;
+        set $index /index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root$index;
+        fastcgi_param SCRIPT_NAME $index;
+        fastcgi_pass atom;
+      }
+    - location ~ ^/private/(.*)$ {
+        internal;
+        alias $atom_path/$1;
+      }
+    - location ~ ^/(index|qubit_dev)\.php(/|$) {
+        include /etc/nginx/fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        fastcgi_read_timeout {{ atom_pool_php_max_execution_time }};
+        fastcgi_pass atom;
+      }
+
+nginx_http_params:
+  - sendfile "on"
+  - tcp_nopush "on"
+  - tcp_nodelay "on"
+  - keepalive_timeout "65"
+  - log_format timed_combined '[$time_local]  $http_x_forwarded_for - $remote_addr $host $remote_user  ' '"$request" $status $body_bytes_sent ' '"$http_referer" "$http_user_agent" $request_time $upstream_response_time $pipe'
+  - access_log "{{ nginx_log_dir }}/access.log" timed_combined
+  - error_log "{{ nginx_log_dir }}/error.log"
+  - server_tokens off
+  - types_hash_max_size 2048
+  - server_names_hash_bucket_size 128
+  - client_max_body_size 72M
+
+# percona role
+
+mysql_version_major: "8"
+mysql_version_minor: "0"
+
+mysql_root_password: "aaGKHyMls.20ki$"
+
+mysql_databases:
+  - name: "{{ atom_config_db_name }}"
+    collation: "{{ mysql_collation_server }}"
+    encoding: "{{ mysql_character_set_server }}"
+
+mysql_users:
+  - name: "{{ atom_mysql_user_name }}"
+    pass: "{{ atom_mysql_user_pass }}"
+    priv: "{{ atom_mysql_user_priv }}"
+    host: "{{ atom_mysql_user_host }}"
+
+mysql_optimizer_switch: "'block_nested_loop=off'"
+mysql_sql_mode: "STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+mysql_bind_address: "0.0.0.0"
+mysql_default_authentication_plugin: "caching_sha2_password"
+
+# elasticsearch role
+
+elasticsearch_version: "5.6.16"

--- a/tests/dip-upload/atom.yml
+++ b/tests/dip-upload/atom.yml
@@ -1,0 +1,151 @@
+---
+- hosts: "all"
+
+  pre_tasks:
+
+    - include_vars: "atom-vars.yml"
+      tags:
+        - "always"
+
+    - name: "Install acl package"
+      package:
+        name: "acl"
+        state: "present"
+      become: "yes"
+
+  roles:
+
+    - role: "artefactual.elasticsearch"
+      become: "yes"
+
+    - role: "artefactual.percona"
+      become: "yes"
+
+    - role: "artefactual.memcached"
+      become: "yes"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+
+    - role: "artefactual.nginx"
+      become: "yes"
+
+    - role: "artefactual-atom"
+      become: "yes"
+      tags:
+        - "atom"
+
+  post_tasks:
+
+    - name: "Define atom_revision_path"
+      set_fact:
+        atom_revision_path: "{{ atom_path + '/' + atom_revision_directory_latest_symlink_dir|default('src') if (atom_revision_directory is defined and atom_revision_directory|bool) else atom_path }}"
+
+    - name: "Configure AtoM DIP Upload in AtoM host"
+      block:
+        - name: "Create archivematica user in AtoM server"
+          user:
+            name: "archivematica"
+            group: "users"
+            system: True
+            home: "/home/archivematica"
+            createhome: True
+            generate_ssh_key: True
+            shell: "/bin/bash"
+
+        - name: "Enable AtoM plug-ins"
+          shell: "php symfony tools:atom-plugins add {{ item }}"
+          args:
+            chdir: "{{ atom_revision_path }}"
+          with_items:
+            - "qtSwordPlugin"
+            - "arRestApiPlugin"
+            - "arStorageServicePlugin"
+
+        - name: "Get nginx user from AtoM (delegated) VM"
+          set_fact:
+            __atom_user: "{% if ansible_os_family in ['RedHat', 'Rocky'] %}nginx{% else %}www-data{% endif %}"
+
+        - name: "Clear AtoM site cache"
+          become_user: "{{ atom_user | default(__atom_user) }}"
+          command: "{{ item }}"
+          args:
+            chdir: "{{ atom_revision_path }}"
+          with_items:
+            - "php symfony cc"
+
+        - name: "Restart services"
+          service:
+            daemon_reload: yes
+            name: "{{ item }}"
+            state: restarted
+          with_items:
+            - "atom-worker"
+
+        - name: "Authorize archivematica SSH key"
+          authorized_key:
+            user: "archivematica"
+            state: "present"
+            key: "{{ archivematica_ssh_pub_key }}"
+
+        - name: "List MySQL AtoM users"
+          command: mysql {{ atom_dip_upload_atom_database }} -Ns -e "select id from user where username='{{ atom_dip_upload_atom_user }}' limit 1;"
+          register: atom_dip_user_id
+
+        - name: "Get property id when {{ atom_dip_upload_atom_user }} AtoM user already exists"
+          command: mysql {{ atom_dip_upload_atom_database }} -Ns -e "select id from property where name='RestApiKey' and object_id='{{ atom_dip_user_id.stdout }}' limit 1;"
+          register: atom_dip_property_id
+          when: atom_dip_user_id.stdout != ""
+
+        - name: "Update Rest API key when {{ atom_dip_upload_atom_user }} AtoM user already exists"
+          command: mysql {{ atom_dip_upload_atom_database }} -Ns -e "UPDATE property_i18n SET value='{{ atom_dip_upload_atom_api_key }}' where id='{{ atom_dip_property_id.stdout }}';"
+          when: atom_dip_property_id.stdout is defined and atom_dip_property_id.stdout != ""
+
+        - name: "Create {{ atom_dip_upload_atom_user }} AtoM user"
+          shell: "php symfony tools:add-superuser --email='{{ atom_dip_upload_atom_email }}' --password='{{ atom_dip_upload_atom_password }}' {{ atom_dip_upload_atom_user }}"
+          args:
+            chdir: "{{  atom_revision_path}}"
+          when: atom_dip_user_id.stdout == ""
+
+        - name: "List MySQL AtoM users again"
+          command: mysql {{ atom_dip_upload_atom_database }} -Ns -e "select id from user where username='{{ atom_dip_upload_atom_user }}' limit 1;"
+          register: atom_dip_user_id_new_user
+          when: atom_dip_user_id.stdout == ""
+
+        - name: "Create Rest API key for new user: {{ atom_dip_upload_atom_user }}"
+          command: mysql {{ atom_dip_upload_atom_database }} -Ns -e "INSERT INTO property (object_id, name, source_culture,id) VALUES( {{ atom_dip_user_id_new_user.stdout }}, 'RestApiKey', 'en', NULL); INSERT INTO property_i18n (value, id, culture) VALUES( '{{ atom_dip_upload_atom_api_key }}', LAST_INSERT_ID(), 'en');"
+          when: atom_dip_user_id.stdout == "" and atom_dip_user_id_new_user.stdout != ""
+
+      become: true
+
+    - name: "Configure SWORD deposit in AtoM host"
+      block:
+        - name: "Create SWORD deposit directory"
+          file:
+            path: "{{ atom_sword_deposit_dir }}"
+            state: "directory"
+            mode: 0770
+            owner: "archivematica"
+            group: "{{ nginx_group }}"
+
+        - name: "Install acl package"
+          package:
+            name: "acl"
+            state: "present"
+
+        - name: "Configure ACL on SWORD deposit directory"
+          acl:
+            default: "yes" # -d option
+            etype: "user"
+            entity: "{{ nginx_user }}"
+            path: "{{ atom_sword_deposit_dir }}"
+            permissions: "rwX"
+            state: "present"
+
+        - name: "Change SWORD deposit in AtoM database"
+          become_user: "{{ nginx_user }}"
+          command: "php symfony tools:settings set sword_deposit_dir {{ atom_sword_deposit_dir }}"
+          args:
+            chdir: "{{ atom_path + '/' + atom_revision_directory_latest_symlink_dir|default('src') if (atom_revision_directory is defined and atom_revision_directory|bool) else atom_path }}"
+
+      become: true

--- a/tests/dip-upload/requirements.yml
+++ b/tests/dip-upload/requirements.yml
@@ -1,0 +1,33 @@
+---
+
+- src: "https://github.com/artefactual-labs/ansible-elasticsearch"
+  version: "master"
+  name: "artefactual.elasticsearch"
+
+- src: "https://github.com/artefactual-labs/ansible-percona"
+  version: "master"
+  name: "artefactual.percona"
+
+- src: "https://github.com/artefactual-labs/ansible-gearman"
+  version: "master"
+  name: "artefactual.gearman"
+
+- src: "https://github.com/artefactual-labs/ansible-nginx"
+  version: "master"
+  name: "artefactual.nginx"
+
+- src: "https://github.com/artefactual-labs/ansible-archivematica-src"
+  version: "qa/1.x"
+  name: "artefactual.archivematica-src"
+
+- src: "https://github.com/artefactual-labs/ansible-clamav"
+  version: "master"
+  name: "artefactual.clamav"
+
+- src: "https://github.com/artefactual-labs/ansible-memcached"
+  version: "master"
+  name: "artefactual.memcached"
+
+- src: "https://github.com/artefactual-labs/ansible-atom"
+  version: "master"
+  name: "artefactual-atom"


### PR DESCRIPTION
Similar to https://github.com/artefactual/deploy-pub/pull/144 this adds a GitHub workflow to test DIP upload from Archivematica to AtoM. The two VMs are provisioned with Vagrant and Ansible.

The workflow can be triggered manually from the Actions tab and it accepts branches, tags or commit hashes for the Archivematica, Storage Service and AtoM checkouts.