### PR TITLE
Pin ansible version in AMAUATs tests

### DIFF
--- a/tests/archivematica-acceptance-tests/requirements.txt
+++ b/tests/archivematica-acceptance-tests/requirements.txt
@@ -1,2 +1,2 @@
-ansible
+ansible<10.0
 git+https://github.com/containers/podman-compose.git@2681566580b4eaadfc5e6000ad19e49e56006e2b#egg=podman-compose


### PR DESCRIPTION
`ansible-core` 2.17+ removes support for discovering Python interpreters with paths other than `python3` which effectively drops support for RHEL 8.

This pins `ansible` to install the last RHEL 8 compatible version of `ansible-core`.

For context see https://github.com/ansible/ansible/issues/83357#issuecomment-2150254754