### PR TITLE
Add GitHub test workflow for AM playbook

### DIFF
--- a/.github/workflows/archivematica-playbook.yml
+++ b/.github/workflows/archivematica-playbook.yml
@@ -1,0 +1,78 @@
+name: Archivematica Playbook Test
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "playbooks/archivematica-jammy/**"
+  push:
+    branches:
+      - "master"
+    paths:
+      - "playbooks/archivematica-jammy/**"
+  schedule:
+    - cron: "0 2 * * *"
+jobs:
+  test:
+    name: Test Archivematica playbook
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: "Create Vagrant boxes directory"
+      run: |
+        mkdir -p /home/runner/.vagrant.d/boxes
+    - name: "Cache Vagrant boxes"
+      uses: "actions/cache@v4"
+      with:
+        path: "/home/runner/.vagrant.d/boxes"
+        key: "${{ runner.os }}-boxes"
+    - name: Install Vagrant
+      run: |
+        wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+        sudo apt update && sudo apt install vagrant
+    - name: Install VirtualBox
+      run: |
+        wget -O- https://www.virtualbox.org/download/oracle_vbox_2016.asc | sudo gpg --yes --output /usr/share/keyrings/oracle-virtualbox-2016.gpg --dearmor
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/oracle-virtualbox-2016.gpg] https://download.virtualbox.org/virtualbox/debian jammy contrib" | sudo tee /etc/apt/sources.list.d/virtualbox.list
+        sudo apt update && sudo apt install virtualbox-7.0
+    - name: "Downgrade VirtualBox"
+      run: |
+        sudo apt-get purge virtualbox-7.0
+        wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
+        sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~jammy_amd64.deb
+    - name: Install the vagrant-vbguest plugin
+      run: |
+        vagrant plugin install vagrant-vbguest
+    - name: Update vbox networks
+      run: |
+        sudo mkdir -p /etc/vbox/
+        echo "* 192.168.168.198/24" | sudo tee -a /etc/vbox/networks.conf
+    - name: Download the Ansible roles
+      working-directory: ${{ github.workspace }}/playbooks/archivematica-jammy
+      run: |
+        ansible-galaxy install -f -p roles/ -r requirements.yml
+    - name: Create the virtual machine and provision it
+      working-directory: ${{ github.workspace }}/playbooks/archivematica-jammy
+      run: |
+        vagrant up
+    - name: Test AM API - Get processing configurations
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:this_is_the_am_api_key' \
+                --header 'Content-Type: application/json' \
+                'http://192.168.168.198/api/processing-configuration/' \
+            | jq -r '.processing_configurations == ["automated", "default"]' \
+        ) == true
+    - name: Test SS API - Get pipeline count
+      run: |
+        test $( \
+            curl \
+                --silent \
+                --header 'Authorization: ApiKey admin:this_is_the_ss_api_key' \
+                --header 'Content-Type: application/json' \
+                'http://192.168.168.198:8000/api/v2/pipeline/' \
+            | jq -r '.meta.total_count == 1' \
+        ) == true

--- a/playbooks/archivematica-jammy/vars-singlenode-1.16.yml
+++ b/playbooks/archivematica-jammy/vars-singlenode-1.16.yml
@@ -23,6 +23,8 @@ archivematica_src_configure_am_email: "admin@example.com"
 archivematica_src_configure_am_api_key: "this_is_the_am_api_key"
 archivematica_src_configure_am_site_url: "http://192.168.168.198"
 
+nodejs_version: "22.x"
+
 # elasticsearch role
 
 elasticsearch_version: "6.5.4"

--- a/playbooks/archivematica-jammy/vars-singlenode-qa.yml
+++ b/playbooks/archivematica-jammy/vars-singlenode-qa.yml
@@ -23,6 +23,8 @@ archivematica_src_configure_am_email: "admin@example.com"
 archivematica_src_configure_am_api_key: "this_is_the_am_api_key"
 archivematica_src_configure_am_site_url: "http://192.168.168.198"
 
+nodejs_version: "22.x"
+
 # elasticsearch role
 
 elasticsearch_version: "6.5.4"


### PR DESCRIPTION
This adds a GitHub workflow named `Archivematica Playbook Test` to test the the Archivematica Jammy playbook in this repository using Vagrant and VirtualBox which can be executed manually from the `Actions` tab.

The Node.js version has been bumped in the variable files because of https://github.com/nodejs/node/issues/50876 which has been fixed in Node.js 21.x.