### PR TITLE
Add Archivematica upgrade test workflow

### DIFF
--- a/.github/workflows/archivematica-upgrade.yml
+++ b/.github/workflows/archivematica-upgrade.yml
@@ -1,0 +1,148 @@
+name: "Archivematica Upgrade Test"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+  pull_request:
+    paths:
+      - "playbooks/archivematica-jammy/**"
+      - "tests/archivematica-upgrade/**"
+      - "!tests/archivematica-upgrade/README.md"
+  push:
+    branches:
+      - "master"
+    paths:
+      - "playbooks/archivematica-jammy/**"
+      - "tests/archivematica-upgrade/**"
+      - "!tests/archivematica-upgrade/README.md"
+jobs:
+  test:
+    name: "Archivematica upgrade test"
+    runs-on: "ubuntu-22.04"
+    env:
+      python_version: "3.12"
+    steps:
+      - name: "Check out the code"
+        uses: "actions/checkout@v4"
+      - name: "Upgrade crun (supports Ubuntu's systemd in the Dockerfile)"
+        run: |
+          wget https://github.com/containers/crun/releases/download/1.15/crun-1.15-linux-amd64
+          sudo install crun-1.15-linux-amd64 /usr/bin/crun
+          rm crun-1.15-linux-amd64
+      - name: "Install Python"
+        uses: "actions/setup-python@v5"
+        with:
+          python-version: "${{ env.python_version }}"
+          cache: "pip"
+          cache-dependency-path: |
+            tests/archivematica-upgrade/requirements.txt
+      - name: "Cache the virtual environment"
+        id: "venv-cache"
+        uses: "actions/cache@v4"
+        with:
+          path: |
+            tests/archivematica-upgrade/.venv/
+          key: "os-${{ runner.os }}-python_version-${{ env.python_version }}-hash-${{ hashFiles('tests/archivematica-upgrade/requirements.txt') }}"
+      - name: "Set up the virtual environment"
+        if: "steps.venv-cache.outputs.cache-hit == false"
+        working-directory: "${{ github.workspace }}/tests/archivematica-upgrade"
+        run: |
+          python3 -m venv .venv
+          .venv/bin/python -m pip install -r requirements.txt
+      - name: "Add virtual environment to PATH"
+        working-directory: "${{ github.workspace }}/tests/archivematica-upgrade"
+        run:
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+      - name: "Generate an SSH key and copy it next to the Dockerfile"
+        run: |
+          mkdir $HOME/.ssh
+          ssh-keygen -t rsa -f $HOME/.ssh/id_rsa -N ""
+          cp $HOME/.ssh/id_rsa.pub ${{ github.workspace }}/tests/archivematica-upgrade/ssh_pub_key
+      - name: "Start the Compose environment"
+        working-directory: "${{ github.workspace }}/tests/archivematica-upgrade"
+        run: |
+          podman-compose up --detach
+      - name: "Install the stable version of Archivematica"
+        working-directory: "${{ github.workspace }}/tests/archivematica-upgrade"
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+          ANSIBLE_REMOTE_PORT: 2222
+        run: |
+          ansible-galaxy install -f -p roles/ -r ../../playbooks/archivematica-jammy/requirements.yml
+          ansible-playbook -i localhost, playbook.yml \
+              -u ubuntu \
+              -e "am_version=1.16" \
+              -e "archivematica_src_configure_am_site_url=http://archivematica" \
+              -e "archivematica_src_configure_ss_url=http://archivematica:8000" \
+              -v
+      - name: "Get the Archivematica version"
+        run: |
+          curl \
+              --silent \
+              --dump-header - \
+              --header 'Authorization: ApiKey admin:this_is_the_am_api_key' \
+              --header 'Content-Type: application/json' \
+              'http://localhost:8000/api/processing-configuration/' | grep X-Archivematica-Version
+      - name: "Call an Archivematica API endpoint"
+        run: |
+          test $( \
+              curl \
+                  --silent \
+                  --header 'Authorization: ApiKey admin:this_is_the_am_api_key' \
+                  --header 'Content-Type: application/json' \
+                  'http://localhost:8000/api/processing-configuration/' \
+              | jq -r '.processing_configurations == ["automated", "default"]' \
+          ) == true
+      - name: "Call a Storage Service API endpoint"
+        run: |
+          test $( \
+              curl \
+                  --silent \
+                  --header 'Authorization: ApiKey admin:this_is_the_ss_api_key' \
+                  --header 'Content-Type: application/json' \
+                  'http://localhost:8001/api/v2/pipeline/' \
+              | jq -r '.meta.total_count == 1' \
+          ) == true
+      - name: "Upgrade to the QA version of Archivematica"
+        working-directory: "${{ github.workspace }}/tests/archivematica-upgrade"
+        env:
+          ANSIBLE_HOST_KEY_CHECKING: "False"
+          ANSIBLE_REMOTE_PORT: 2222
+        run: |
+          rm -rf roles
+          ansible-galaxy install -f -p roles/ -r ../../playbooks/archivematica-jammy/requirements-qa.yml
+          ansible-playbook -i localhost, playbook.yml \
+              -u ubuntu \
+              -e "am_version=qa" \
+              -e "archivematica_src_configure_am_site_url=http://archivematica" \
+              -e "archivematica_src_configure_ss_url=http://archivematica:8000" \
+              -t "archivematica-src" \
+              -v
+      - name: "Get the Archivematica version"
+        run: |
+          curl \
+              --silent \
+              --dump-header - \
+              --header 'Authorization: ApiKey admin:this_is_the_am_api_key' \
+              --header 'Content-Type: application/json' \
+              'http://localhost:8000/api/processing-configuration/' | grep X-Archivematica-Version
+      - name: "Call an Archivematica API endpoint"
+        run: |
+          test $( \
+              curl \
+                  --silent \
+                  --header 'Authorization: ApiKey admin:this_is_the_am_api_key' \
+                  --header 'Content-Type: application/json' \
+                  'http://localhost:8000/api/processing-configuration/' \
+              | jq -r '.processing_configurations == ["automated", "default"]' \
+          ) == true
+      - name: "Call a Storage Service API endpoint"
+        run: |
+          test $( \
+              curl \
+                  --silent \
+                  --header 'Authorization: ApiKey admin:this_is_the_ss_api_key' \
+                  --header 'Content-Type: application/json' \
+                  'http://localhost:8001/api/v2/pipeline/' \
+              | jq -r '.meta.total_count == 1' \
+          ) == true

--- a/tests/archivematica-upgrade/.gitignore
+++ b/tests/archivematica-upgrade/.gitignore
@@ -1,0 +1,3 @@
+ssh_pub_key
+.venv
+roles

--- a/tests/archivematica-upgrade/Dockerfile
+++ b/tests/archivematica-upgrade/Dockerfile
@@ -1,0 +1,19 @@
+ARG UBUNTU_VERSION=22.04
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y sudo openssh-server rsync locales && apt-get clean
+
+RUN useradd --home-dir /home/ubuntu --system ubuntu
+
+COPY --chown=ubuntu:ubuntu --chmod=600 ssh_pub_key /home/ubuntu/.ssh/authorized_keys
+
+RUN mkdir -p /etc/sudoers.d/ && echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ubuntu
+
+EXPOSE 22
+EXPOSE 80
+EXPOSE 8000
+
+CMD [ "/sbin/init" ]

--- a/tests/archivematica-upgrade/README.md
+++ b/tests/archivematica-upgrade/README.md
@@ -1,0 +1,138 @@
+# Archivematica playbook upgrade test
+
+## Software requirements
+
+- Podman
+- crun >= 1.14.4
+- Python 3
+- curl
+
+## Installing Ansible
+
+Create a virtual environment and activate it:
+
+```shell
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the Python requirements (these versions are compatible with
+symbolic links which are used in the the artefactual-atom role):
+
+```shell
+python3 -m pip install -r requirements.txt
+```
+
+## Starting the Compose environment
+
+Copy your SSH public key as the `ssh_pub_key` file next to the `Dockerfile`:
+
+```shell
+cp $HOME/.ssh/id_rsa.pub ssh_pub_key
+```
+
+Start the Compose services:
+
+```shell
+podman-compose up --detach
+```
+
+## Installing the stable version of Archivematica
+
+Install the requirements of the stable version:
+
+```shell
+ansible-galaxy install -f -p roles/ -r ../../playbooks/archivematica-jammy/requirements.yml
+```
+
+Run the Archivematica installation playbook passing the stable version as the
+`am_version` variable and the proper URLs for the Compose environment:
+
+```shell
+export ANSIBLE_HOST_KEY_CHECKING=False
+export ANSIBLE_REMOTE_PORT=2222
+ansible-playbook -i localhost, playbook.yml \
+    -u ubuntu \
+    -e "am_version=1.16" \
+    -e "archivematica_src_configure_am_site_url=http://archivematica" \
+    -e "archivematica_src_configure_ss_url=http://archivematica:8000" \
+    -v
+```
+
+## Testing the stable version of Archivematica
+
+Get the Archivematica stable version:
+
+```shell
+curl \
+    --silent \
+    --dump-header - \
+    --header "Authorization: ApiKey admin:this_is_the_am_api_key" \
+    http://localhost:8000/api/processing-configuration/ | grep X-Archivematica-Version
+```
+
+Call an Archivematica API endpoint:
+
+```shell
+curl --header "Authorization: ApiKey admin:this_is_the_am_api_key" http://localhost:8000/api/processing-configuration/
+```
+
+Call a Storage Service API endpoint:
+
+```shell
+curl --header "Authorization: ApiKey admin:this_is_the_ss_api_key" http://localhost:8001/api/v2/pipeline/
+```
+
+## Upgrading to the QA version of Archivematica
+
+Delete the requirements directory used for the stable version:
+
+```shell
+rm -rf roles
+```
+
+Install the requirements of the QA version:
+
+```shell
+ansible-galaxy install -f -p roles/ -r ../../playbooks/archivematica-jammy/requirements-qa.yml
+```
+
+Run the Archivematica installation playbook passing the QA version as the
+`am_version` variable, the proper URLs for the Compose environment and
+the tag to upgrade installations:
+
+```shell
+export ANSIBLE_HOST_KEY_CHECKING=False
+export ANSIBLE_REMOTE_PORT=2222
+ansible-playbook -i localhost, playbook.yml \
+    -u ubuntu \
+    -e "am_version=qa" \
+    -e "archivematica_src_configure_am_site_url=http://archivematica" \
+    -e "archivematica_src_configure_ss_url=http://archivematica:8000" \
+    -t "archivematica-src" \
+    -v
+```
+
+## Testing the QA version of Archivematica
+
+Get the Archivematica QA version:
+
+```shell
+curl \
+    --silent \
+    --dump-header - \
+    --header "Authorization: ApiKey admin:this_is_the_am_api_key" \
+    http://localhost:8000/api/processing-configuration/ | grep X-Archivematica-Version
+```
+
+Call an Archivematica API endpoint:
+
+```shell
+curl --header "Authorization: ApiKey admin:this_is_the_am_api_key" http://localhost:8000/api/processing-configuration/
+```
+
+Call a Storage Service API endpoint:
+
+```shell
+curl --header "Authorization: ApiKey admin:this_is_the_ss_api_key" http://localhost:8001/api/v2/pipeline/
+```

--- a/tests/archivematica-upgrade/compose.yaml
+++ b/tests/archivematica-upgrade/compose.yaml
@@ -1,0 +1,13 @@
+---
+name: archivematica-upgrade-test
+
+services:
+
+  archivematica:
+    build:
+      args:
+        UBUNTU_VERSION: "22.04"
+    ports:
+      - "2222:22"
+      - "8000:80"
+      - "8001:8000"

--- a/tests/archivematica-upgrade/playbook.yml
+++ b/tests/archivematica-upgrade/playbook.yml
@@ -1,0 +1,57 @@
+---
+- hosts: "all"
+
+  pre_tasks:
+
+    - include_vars: "../../playbooks/archivematica-jammy/vars-singlenode-{{ am_version }}.yml"
+      tags:
+        - "always"
+
+    - name: "Install packages for development convenience"
+      apt:
+        pkg: "{{ item }}"
+        state: "latest"
+      with_items:
+        - "fish"
+      become: "yes"
+
+  roles:
+
+    - role: "artefactual.elasticsearch"
+      become: "yes"
+      tags:
+        - "elasticsearch"
+      when: "archivematica_src_search_enabled|bool"
+
+    - role: "artefactual.percona"
+      become: "yes"
+      tags:
+        - "percona"
+
+    - role: "artefactual.nginx"
+      become: "yes"
+      tags:
+        - "nginx"
+
+    - role: "artefactual.gearman"
+      become: "yes"
+      tags:
+        - "gearman"
+
+    - role: "artefactual.clamav"
+      become: "yes"
+      tags:
+        - "clamav"
+
+    - role: "artefactual.archivematica-src"
+      become: "yes"
+      tags:
+        - "archivematica-src"
+
+  post_tasks:
+
+    - name: "change home dir perms (to make transfer source visible)"
+      become: "no"
+      command: "chmod 755 $HOME"
+      tags:
+        - "homeperms"

--- a/tests/archivematica-upgrade/requirements.txt
+++ b/tests/archivematica-upgrade/requirements.txt
@@ -1,0 +1,2 @@
+ansible
+git+https://github.com/containers/podman-compose.git@2681566580b4eaadfc5e6000ad19e49e56006e2b#egg=podman-compose


### PR DESCRIPTION
Similarly to https://github.com/artefactual/deploy-pub/pull/146 and https://github.com/artefactual/deploy-pub/pull/148 this adds a very basic GitHub workflow to test Archivematica upgrades.

It's implemented with a [Podman](https://podman.io/) container orchestrated with [podman-compose](https://github.com/containers/podman-compose) and it reuses the requirements and variables included in the `archivematica-jammy` playbook.

The workflow can be triggered manually from the Actions tab.

![Captura desde 2024-10-08 12-26-42](https://github.com/user-attachments/assets/4177faa6-91f5-4d08-8de5-df479ef828cb)

For now it only shows the `X-Archivematica-Version` header set by the Dashboard API before and after the upgrade and calls a couple of API endpoints, but we can extend it in the future with more assertive steps that guarantee behavior is maintained across versions (e.g. running transfers, downloading AIPs, searching, etc).