### PR TITLE
Remove vagrant-vbguest plugin from AM playbook

### DIFF
--- a/.github/workflows/archivematica-playbook.yml
+++ b/.github/workflows/archivematica-playbook.yml
@@ -41,9 +41,6 @@ jobs:
         sudo apt-get purge virtualbox-7.0
         wget -O /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb -L https://download.virtualbox.org/virtualbox/7.0.14/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb
         sudo dpkg -i /tmp/virtualbox-7.0_7.0.14-161095~Ubuntu~focal_amd64.deb
-    - name: Install the vagrant-vbguest plugin
-      run: |
-        vagrant plugin install vagrant-vbguest
     - name: Update vbox networks
       run: |
         sudo mkdir -p /etc/vbox/

--- a/playbooks/archivematica-jammy/README.md
+++ b/playbooks/archivematica-jammy/README.md
@@ -54,14 +54,6 @@ machine.
 
 6. The ansible playbook `singlenode.yml` specified in the Vagrantfile will provision using qa branches of archivematica. To provision using the stable 1.16.x/0.22.x branches, replace "vars-singlenode-qa.yml" with "vars-singlenode-1.16.yml" in `singlenode.yml`. You can also modify create a custom vars file and pass it instead (to modify role variables to deploy custom branches, etc.)
 
-7. If you get errors regarding the Vagrant shared folders, they are usually due
-to different versions of VirtualBox. One way to fix it is using a vagrant
-plugin that installs the host's VirtualBox Guest Additions on the guest system:
-  ```
-  $ vagrant plugin install vagrant-vbguest
-  $ vagrant vbguest
-  ```
-
 # Login and credentials
 
 If you are using the default values in vars-singlenode-XXXX.yml and Vagrantfile files, the login URLS are:


### PR DESCRIPTION
The plugin is [not maintained anymore](https://github.com/dotless-de/vagrant-vbguest?tab=readme-ov-file#vagrant-vbguest) and the playbook does not require its functionality. Also the 2.4.2 release of Vagrant broke plugin installation.