### PR TITLE
Set user variables in AM playbook workflow

### DIFF
--- a/.github/workflows/archivematica-playbook.yml
+++ b/.github/workflows/archivematica-playbook.yml
@@ -40,6 +40,10 @@ jobs:
       run: |
         sudo mkdir -p /etc/vbox/
         echo "* 192.168.168.198/24" | sudo tee -a /etc/vbox/networks.conf
+    - name: Set the user environment as VirtualBox expects it
+      run: |
+        echo "USER=$USER" >> $GITHUB_ENV
+        echo "LOGNAME=$USER" >> $GITHUB_ENV
     - name: Download the Ansible roles
       working-directory: ${{ github.workspace }}/playbooks/archivematica-jammy
       run: |
@@ -47,10 +51,7 @@ jobs:
     - name: Create the virtual machine and provision it
       working-directory: ${{ github.workspace }}/playbooks/archivematica-jammy
       run: |
-        sudo mkdir -p /root/.vagrant.d
-        sudo ln -s /home/runner/.vagrant.d/boxes /root/.vagrant.d/boxes
-        sudo pip install ansible
-        sudo vagrant up
+        vagrant up
     - name: Test AM API - Get processing configurations
       run: |
         test $( \


### PR DESCRIPTION
This removes the need to run the `vagrant` command using `sudo` and to provide the `root` user access to the Vagrant boxes cache.