### PR TITLE
Run AtoM on Ubuntu 24.04 in DIP upload test

### DIFF
--- a/.github/workflows/dip-upload.yml
+++ b/.github/workflows/dip-upload.yml
@@ -168,3 +168,19 @@ jobs:
           curl \
               --header "REST-API-Key: this_is_the_atom_dip_upload_api_key" \
               http://localhost:9000/index.php/api/informationobjects/beihai-guanxi-china-1988 | python3 -m json.tool | grep '"parent": "example-item"'
+      - name: "Save logs on failure"
+        if: "${{ failure() }}"
+        run: |
+          mkdir logs
+          podman-compose exec --user root archivematica journalctl -u archivematica-mcp-client --no-pager > logs/mcp-client.log
+          podman-compose exec --user root atom journalctl -u atom-worker --no-pager > logs/atom-worker.log
+          podman cp dip-upload-test_atom_1:/usr/share/nginx/atom/log/qubit_worker.log logs/qubit_worker.log
+          podman cp dip-upload-test_atom_1:/usr/share/nginx/atom/log/qubit_prod.log logs/qubit_prod.log
+          podman cp dip-upload-test_atom_1:/usr/share/nginx/atom/log/qubit_cli.log logs/qubit_cli.log
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+      - name: "Upload logs on failure"
+        if: "${{ failure() }}"
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "logs"
+          path: "${{ github.workspace }}/tests/dip-upload/logs"

--- a/.github/workflows/dip-upload.yml
+++ b/.github/workflows/dip-upload.yml
@@ -140,6 +140,10 @@ jobs:
           podman-compose exec --user archivematica archivematica sed --in-place 's|612e3609-ce9a-4df6-a9a3-63d634d2d934|b93cecd4-71f2-4e28-bc39-d32fd62c5a94|g' /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/dipuploadProcessingMCP.xml
           # Change 'Do not upload DIP' to 'Upload DIP to AtoM/Binder'
           podman-compose exec --user archivematica archivematica sed --in-place 's|6eb8ebe7-fab3-4e4c-b9d7-14de17625baa|0fe9842f-9519-4067-a691-8a363132ae24|g' /var/archivematica/sharedDirectory/sharedMicroServiceTasksConfigs/processingMCPConfigs/dipuploadProcessingMCP.xml
+      - name: "Adjust SWORD deposit directory permission"
+        working-directory: "${{ github.workspace }}/tests/dip-upload"
+        run: |
+          podman-compose exec --user root atom chmod +rx /home/archivematica/
       - name: "Import the Atom sample data"
         working-directory: "${{ github.workspace }}/tests/dip-upload"
         run: |

--- a/tests/dip-upload/Dockerfile
+++ b/tests/dip-upload/Dockerfile
@@ -4,6 +4,13 @@ FROM ubuntu:${UBUNTU_VERSION}
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Ubuntu 24.04 and later Docker images include a default user with UID (1000)
+# and GID (1000). Remove this user to prevent conflicts with the USER_ID and
+# GROUP_ID build arguments.
+RUN set -ex \
+  && id -u ubuntu >/dev/null 2>&1 \
+  && userdel --remove ubuntu || true
+
 RUN apt-get update && apt-get install -y sudo openssh-server rsync locales && apt-get clean
 
 RUN useradd --home-dir /home/ubuntu --system ubuntu

--- a/tests/dip-upload/compose.yaml
+++ b/tests/dip-upload/compose.yaml
@@ -15,7 +15,7 @@ services:
   atom:
     build:
       args:
-        UBUNTU_VERSION: "20.04"
+        UBUNTU_VERSION: "24.04"
     ports:
       - "9222:22"
       - "9000:80"

--- a/tests/dip-upload/requirements.yml
+++ b/tests/dip-upload/requirements.yml
@@ -29,5 +29,5 @@
   name: "artefactual.memcached"
 
 - src: "https://github.com/artefactual-labs/ansible-atom"
-  version: "master"
+  version: "dev/ubuntu-24-atom"
   name: "artefactual-atom"

--- a/tests/dip-upload/requirements.yml
+++ b/tests/dip-upload/requirements.yml
@@ -29,5 +29,5 @@
   name: "artefactual.memcached"
 
 - src: "https://github.com/artefactual-labs/ansible-atom"
-  version: "dev/ubuntu-24-atom"
+  version: "master"
   name: "artefactual-atom"


### PR DESCRIPTION
This fixes the DIP upload test CI workflow which fails because AtoM's `qa/2.x` branch is not compatible with Ubuntu 20.04 and PHP 7.x anymore.

![imagen](https://github.com/user-attachments/assets/784a1f90-03da-433c-890b-202773651981)

Co-authored-by: Anvit Srivastav <asrivastav@artefactual.com>